### PR TITLE
Fix constant-time vulnerabilities in ML-KEM-768 decapsulation

### DIFF
--- a/src/crypto/ml-kem.lisp
+++ b/src/crypto/ml-kem.lisp
@@ -741,7 +741,9 @@ Returns (values shared-secret ciphertext)."
 
 (defun ml-kem-768-decaps (dk c)
   "Decapsulate shared secret from ciphertext C using decapsulation key DK.
-Returns 32-byte shared secret."
+Returns 32-byte shared secret.  Per FIPS 203 S7.3, uses constant-time
+selection between the real shared secret and implicit rejection value
+to prevent side-channel distinguishability."
   (let* ((k +ml-kem-768-k+)
          ;; Parse dk = dk_pke || ek || H(ek) || z
          (dk-pke-len (* 384 k))
@@ -761,22 +763,12 @@ Returns 32-byte shared secret."
          (k-prime (subseq g-output 0 32))
          (r-prime (subseq g-output 32 64))
          ;; c' = Encrypt(ek, m', r')
-         (c-prime (k-pke-encrypt ek m-prime r-prime)))
-    ;; Constant-time comparison and selection
-    (if (constant-time-equal c c-prime)
-        k-prime
-        ;; Implicit rejection: return J(z || c)
-        (shake256-xof (concatenate '(vector (unsigned-byte 8)) z c) 32))))
-
-(defun constant-time-equal (a b)
-  "Constant-time comparison of byte vectors A and B."
-  (declare (type (simple-array (unsigned-byte 8) (*)) a b)
-           (optimize speed))
-  (and (= (length a) (length b))
-       (zerop (loop with diff of-type (unsigned-byte 8) = 0
-                    for i from 0 below (length a)
-                    do (setf diff (logior diff (logxor (aref a i) (aref b i))))
-                    finally (return diff)))))
+         (c-prime (k-pke-encrypt ek m-prime r-prime))
+         ;; Always compute the rejection value (implicit rejection per FIPS 203)
+         (k-reject (shake256-xof (concatenate '(vector (unsigned-byte 8)) z c) 32))
+         ;; Constant-time: derive mask from comparison, select without branching
+         (mask (ct-equal-mask c c-prime)))
+    (ct-select mask k-prime k-reject)))
 
 ;;;; =========================================================================
 ;;;; TLS Hybrid Key Exchange: X25519MLKEM768 (FIPS 203)

--- a/src/utils.lisp
+++ b/src/utils.lisp
@@ -222,6 +222,41 @@
    Delegates to Ironclad's implementation for proper side-channel resistance."
   (ironclad:constant-time-equal a b))
 
+(defun ct-equal-mask (a b)
+  "Return #xFF if byte vectors A and B are equal, #x00 otherwise.
+Constant-time: always iterates over all bytes, folds length mismatch
+into the accumulator rather than short-circuiting."
+  (declare (type (simple-array (unsigned-byte 8) (*)) a b)
+           (optimize speed))
+  (let ((len-a (length a))
+        (len-b (length b)))
+    (declare (type fixnum len-a len-b))
+    (let ((diff (logand #xff (logxor len-a len-b))))
+      (declare (type (unsigned-byte 8) diff))
+      (loop for i fixnum from 0 below (min len-a len-b)
+            do (setf diff (logior diff (logxor (aref a i) (aref b i)))))
+      ;; diff=0 → #xFF, diff≠0 → #x00
+      ;; Note: intermediate (- diff) may produce a negative fixnum, but the
+      ;; final logand #xff masks to the correct byte result.
+      (logand #xff (lognot (ash (logior diff (- diff)) -7))))))
+
+(defun ct-select (mask a b)
+  "Constant-time select: return A if MASK is #xFF, B if MASK is #x00.
+MASK must be either #x00 or #xFF.  A and B must be byte vectors of
+the same length.  Selection is performed byte-by-byte without branching."
+  (declare (type (unsigned-byte 8) mask)
+           (type (simple-array (unsigned-byte 8) (*)) a b)
+           (optimize speed))
+  (assert (= (length a) (length b)))
+  (let* ((len (length a))
+         (result (make-array len :element-type '(unsigned-byte 8))))
+    (declare (type fixnum len))
+    (loop for i fixnum from 0 below len
+          do (setf (aref result i)
+                   (logxor (aref b i)
+                           (logand mask (logxor (aref a i) (aref b i))))))
+    result))
+
 ;;;; Secret Zeroization
 ;;;
 ;;; Wipe sensitive data from memory to reduce exposure window.

--- a/test/crypto-tests.lisp
+++ b/test/crypto-tests.lisp
@@ -215,6 +215,57 @@
     (is (not (pure-tls:constant-time-equal a b))
         "Vectors of different length should not compare equal")))
 
+;;;; Constant-Time Primitive Tests
+
+(test ct-equal-mask-equal
+  "ct-equal-mask returns #xFF for equal vectors"
+  (let ((a (hex-to-bytes "deadbeef"))
+        (b (hex-to-bytes "deadbeef")))
+    (is (= #xff (pure-tls::ct-equal-mask a b)))))
+
+(test ct-equal-mask-different
+  "ct-equal-mask returns #x00 for different vectors"
+  (let ((a (hex-to-bytes "deadbeef"))
+        (b (hex-to-bytes "deadbee0")))
+    (is (= #x00 (pure-tls::ct-equal-mask a b)))))
+
+(test ct-equal-mask-different-length
+  "ct-equal-mask returns #x00 for length-mismatched vectors"
+  (let ((a (hex-to-bytes "deadbeef"))
+        (b (hex-to-bytes "deadbeefcafe")))
+    (is (= #x00 (pure-tls::ct-equal-mask a b)))))
+
+(test ct-select-mask-ff
+  "ct-select with #xFF mask returns first vector"
+  (let ((a (hex-to-bytes "0102030405060708"))
+        (b (hex-to-bytes "f1f2f3f4f5f6f7f8")))
+    (is (bytes-equal (pure-tls::ct-select #xff a b) a))))
+
+(test ct-select-mask-00
+  "ct-select with #x00 mask returns second vector"
+  (let ((a (hex-to-bytes "0102030405060708"))
+        (b (hex-to-bytes "f1f2f3f4f5f6f7f8")))
+    (is (bytes-equal (pure-tls::ct-select #x00 a b) b))))
+
+(test ml-kem-768-decaps-branchless
+  "ML-KEM-768 decapsulation uses branchless selection (implicit rejection returns value, not error)"
+  (multiple-value-bind (ek dk)
+      (pure-tls::ml-kem-768-keygen)
+    (multiple-value-bind (ss ct)
+        (pure-tls::ml-kem-768-encaps ek)
+      ;; Valid decapsulation
+      (let ((ss-dec (pure-tls::ml-kem-768-decaps dk ct)))
+        (is (bytes-equal ss ss-dec)
+            "Valid ciphertext should produce matching shared secret"))
+      ;; Corrupted ciphertext should return implicit rejection, not error
+      (let ((bad-ct (copy-seq ct)))
+        (setf (aref bad-ct 0) (logxor (aref bad-ct 0) #xff))
+        (let ((bad-ss (pure-tls::ml-kem-768-decaps dk bad-ct)))
+          (is (= (length bad-ss) 32)
+              "Implicit rejection should return 32 bytes")
+          (is (not (bytes-equal ss bad-ss))
+              "Corrupted ciphertext should not produce the real shared secret"))))))
+
 ;;;; Random Bytes Tests
 
 (test random-bytes-length


### PR DESCRIPTION
## Summary

Supersedes #4 — incorporates review feedback from @atgreen and @jcmallery.

Fixes two side-channel vulnerabilities in ML-KEM-768 decapsulation:

1. **Non-constant-time branch in `ml-kem-768-decaps`:** The `IF` after `constant-time-equal` created timing-observable code paths — the rejection path called `shake256-xof` and `concatenate` while the success path returned immediately. This violates FIPS 203 §7.3 which requires implicit rejection to be indistinguishable from valid decapsulation. **Fix:** always compute both values, select with branchless `ct-select`.

2. **Duplicate `constant-time-equal` in ml-kem.lisp:** Per @atgreen's review, removed this copy — `src/utils.lisp` already has one delegating to Ironclad. The duplicate also had a short-circuiting length check.

**Changes:**
- Remove duplicate `constant-time-equal` from `ml-kem.lisp`, use the `utils.lisp` version
- Add `ct-equal-mask` and `ct-select` to `utils.lisp` as reusable constant-time primitives
- Rewrite `ml-kem-768-decaps` to use branchless selection
- Add tests for `ct-equal-mask`, `ct-select`, and branchless decapsulation

## Test plan

- [x] ML-KEM-768 encaps/decaps round-trip produces matching shared secrets
- [x] Decapsulation with corrupted ciphertext returns implicit rejection value (not an error)
- [x] `ct-equal-mask` returns #xFF for equal vectors, #x00 for unequal
- [x] `ct-equal-mask` handles length-mismatched vectors without short-circuiting
- [x] `ct-select` with #xFF mask returns first vector, #x00 returns second
- [x] All existing ML-KEM and constant-time-equal tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)