### PR TITLE
fix(context): fail closed on an unusable explicit CA source

### DIFF
--- a/src/context.lisp
+++ b/src/context.lisp
@@ -101,10 +101,29 @@
             (load-private-key private-key-file)))
     ;; Load trusted CAs
     (cond
-      ;; Explicit CA file or directory specified
+      ;; Explicit CA file or directory specified: fail closed.
+      ;; A caller who names :ca-file / :ca-directory is asserting a
+      ;; specific set of trust anchors. If that source cannot be read
+      ;; (missing/unreadable/directory) or yields zero usable anchors
+      ;; (empty or non-PEM garbage), that is a misconfiguration, not a
+      ;; silent trust-nothing store. Resignal any non-tls-error as a
+      ;; catchable tls-certificate-error so a non-interactive consumer's
+      ;; fail-closed handler catches it instead of the image dying on a
+      ;; raw file-error. (The system auto-load path below stays
+      ;; warn-and-continue; only an explicit source fails closed.)
       ((or ca-file ca-directory)
-       (setf (tls-context-trust-store ctx)
-             (make-trust-store-from-sources ca-file ca-directory)))
+       (let ((store
+               (handler-case (make-trust-store-from-sources ca-file ca-directory)
+                 (tls-error (e) (error e))
+                 (error (e)
+                   (error 'tls-certificate-error
+                          :message (format nil "Failed to load CA trust store from~@[ file ~S~]~@[ directory ~S~]: ~A"
+                                           ca-file ca-directory e))))))
+         (unless (trust-store-certificates store)
+           (error 'tls-certificate-error
+                  :message (format nil "CA trust store from~@[ file ~S~]~@[ directory ~S~] contains no usable certificates"
+                                   ca-file ca-directory)))
+         (setf (tls-context-trust-store ctx) store)))
       ;; Auto-load system CAs if verify-required and enabled
       ((and auto-load-system-ca
             (= verify-mode +verify-required+))

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -351,6 +351,70 @@
         (pure-tls::session-ticket-cache-clear host)
         (ignore-errors (bt:join-thread thread))))))
 
+;;;; ---------------------------------------------------------------------------
+;;;; Finding: an unusable explicit :ca-file crashes the image instead of
+;;;; signalling a catchable condition.
+;;;;
+;;;; make-tls-context's explicit-CA branch loaded the trust store through
+;;;; read-file-bytes, which opens with-open-file with no :if-does-not-exist,
+;;;; so a missing/unreadable file raised a raw FILE-ERROR.  FILE-ERROR is not
+;;;; a subtype of PURE-TLS:TLS-ERROR, so a non-interactive consumer's
+;;;; fail-closed handler (which catches only the tls-error family) could not
+;;;; catch it and the image died.  A garbage or empty file was worse: the
+;;;; parser swallowed the decode error and returned an empty trust store, so
+;;;; the context silently trusted nothing.
+;;;;
+;;;; Secure behaviour: an explicitly-named CA source that cannot be read or
+;;;; that yields zero trust anchors is a misconfiguration -- make-tls-context
+;;;; must fail closed with a catchable PURE-TLS:TLS-CERTIFICATE-ERROR and the
+;;;; image must survive.  Each case passes :auto-load-system-ca nil so the bad
+;;;; file is the only trust source (no accidental system-store fallback).
+;;;; ---------------------------------------------------------------------------
+
+(test explicit-ca-source-fails-closed
+  "An unusable explicit :ca-file must signal a catchable tls-error-family
+   condition, never crash the image with a raw file-error."
+  (let* ((dir (uiop:temporary-directory))
+         (empty (merge-pathnames "pure-tls-fail-closed-empty.pem" dir))
+         (garbage (merge-pathnames "pure-tls-fail-closed-garbage.pem" dir))
+         (missing (merge-pathnames "pure-tls-fail-closed-does-not-exist.pem" dir)))
+    (unwind-protect
+         (progn
+           ;; Empty file: zero certificates parse -> fail closed on empty store.
+           (with-open-file (s empty :direction :output :if-exists :supersede
+                                    :if-does-not-exist :create
+                                    :element-type '(unsigned-byte 8)))
+           ;; Garbage non-PEM bytes (invalid UTF-8 lead bytes): decode/parse
+           ;; failure -> resignalled as a certificate error.
+           (with-open-file (s garbage :direction :output :if-exists :supersede
+                                      :if-does-not-exist :create
+                                      :element-type '(unsigned-byte 8))
+             (write-sequence #(255 254 0 1 2 3 128 200 66 66 7 7) s))
+           ;; Make sure the "missing" path really is absent.
+           (ignore-errors (delete-file missing))
+           ;; Missing path (guaranteed absent).
+           (signals pure-tls:tls-certificate-error
+             (pure-tls:make-tls-context :ca-file (namestring missing)
+                                        :auto-load-system-ca nil))
+           ;; Empty file (zero usable anchors).
+           (signals pure-tls:tls-certificate-error
+             (pure-tls:make-tls-context :ca-file (namestring empty)
+                                        :auto-load-system-ca nil))
+           ;; Garbage non-PEM file.
+           (signals pure-tls:tls-certificate-error
+             (pure-tls:make-tls-context :ca-file (namestring garbage)
+                                        :auto-load-system-ca nil))
+           ;; Not-a-regular-file: pass the temp directory itself.  Opening a
+           ;; directory as a file signals an error, which is portable AND
+           ;; root-safe -- chmod 000 is bypassed when the suite runs as root,
+           ;; so we deliberately use a directory path rather than an unreadable
+           ;; regular file.
+           (signals pure-tls:tls-certificate-error
+             (pure-tls:make-tls-context :ca-file (namestring dir)
+                                        :auto-load-system-ca nil)))
+      (ignore-errors (delete-file empty))
+      (ignore-errors (delete-file garbage)))))
+
 ;;;; Test Runner
 
 (defun run-security-regression-tests ()


### PR DESCRIPTION
Follow-up #2 from #11 — a small, narrowly-scoped behavior change (the first
one in this series that isn't test-only), so I want to be explicit about who
it affects.

When a caller names an explicit `:ca-file` or `:ca-directory` that is
unreadable, empty, or malformed, `make-tls-context` currently builds a silent
trust-nothing store: every certificate then fails verification with no hint
that the configured trust source was the cause. This makes it signal at
context creation instead, so a misconfigured explicit source is a clear,
immediate error rather than a confusing downstream verification failure.

The scope is deliberately narrow:

- Only an **explicitly named** source (`:ca-file` / `:ca-directory`) is
  treated as fail-closed.
- The **system-CA auto-load** path is unchanged — it stays warn-and-continue,
  so nothing changes for callers relying on the default trust store.

Who this affects: a caller passing an explicit CA path that doesn't resolve to
usable certificates now gets a `tls-certificate-error` at `make-tls-context`
time, instead of a context that silently distrusts everything. If you'd rather
keep the current behavior or gate this behind a keyword, happy to adjust.

Includes a regression test that builds contexts against empty and malformed CA
files and asserts each signals `tls-certificate-error`. Verified green against
current master (full suite 362/0).
