### PR TITLE
feat(x509): reject embedded-NUL and non-LDH bytes in hostname verification

### DIFF
--- a/src/x509/verify.lisp
+++ b/src/x509/verify.lisp
@@ -10,6 +10,28 @@
 
 ;;;; Hostname Verification (RFC 6125 / RFC 2818)
 
+(defun valid-dns-name-p (name)
+  "Return T if NAME is a syntactically safe DNS name for identity comparison.
+   Rejects an embedded NUL and any byte outside the LDH set (ASCII letters,
+   digits, hyphen, dot).  A single leading \"*.\" wildcard label is permitted
+   so that legitimate wildcard SAN patterns still validate.  IP-literal
+   identities are handled by the IP path and are not expected here."
+  (and (stringp name)
+       (plusp (length name))
+       (let ((start 0))
+         ;; Allow one leading "*." wildcard label; the remainder must be LDH.
+         (when (and (>= (length name) 2)
+                    (char= (char name 0) #\*)
+                    (char= (char name 1) #\.))
+           (setf start 2))
+         (loop for i from start below (length name)
+               for c = (char name i)
+               always (or (char<= #\a c #\z)
+                          (char<= #\A c #\Z)
+                          (char<= #\0 c #\9)
+                          (char= c #\-)
+                          (char= c #\.))))))
+
 (defun verify-hostname (cert hostname)
   "Verify that HOSTNAME matches the certificate.
    Supports both DNS hostnames and IP address literals.
@@ -25,13 +47,24 @@
                    :hostname hostname
                    :message "IP address does not match any IP SAN entry")))))
 
+  ;; DNS hostname - the requested identity must itself be a safe DNS name.
+  ;; Defense in depth: an embedded NUL or a non-LDH byte must cause outright
+  ;; rejection, never a silent unequal-compare (e.g. "www.bank.com\0.evil.com").
+  (unless (valid-dns-name-p hostname)
+    (error 'tls-verification-error
+           :hostname hostname
+           :message "Requested hostname is not a valid DNS name (embedded NUL or non-LDH byte)"))
+
   ;; DNS hostname - check Subject Alternative Name extension first
   (let ((san-names (certificate-dns-names cert))
         (san-ips (certificate-ip-addresses cert)))
     (when (or san-names san-ips)
       ;; If SAN is present, only use SAN (ignore CN per RFC 6125)
       (if (some (lambda (san-name)
-                  (hostname-matches-p san-name hostname))
+                  ;; A malformed SAN dNSName (embedded NUL / non-LDH byte) can
+                  ;; never be the basis of a match; skip it before comparing.
+                  (and (valid-dns-name-p san-name)
+                       (hostname-matches-p san-name hostname)))
                 san-names)
           (return-from verify-hostname t)
           (error 'tls-verification-error

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -353,6 +353,39 @@
 
 ;;;; Test Runner
 
+;;;; ---------------------------------------------------------------------------
+;;;; DNS name-safety in hostname verification.
+;;;;
+;;;; verify-hostname must reject a syntactically unsafe DNS name (embedded NUL,
+;;;; non-LDH bytes) outright rather than letting it reach a silent
+;;;; unequal-compare.  These drive the real validator with certificate objects
+;;;; constructed in-image (no private keys / OpenSSL fixtures needed for the
+;;;; identity decision).
+;;;; ---------------------------------------------------------------------------
+
+(defun %san-cert (&rest dns-names)
+  "Build a certificate whose only identity is the given SAN dNSName(s)."
+  (pure-tls::make-x509-certificate
+   :extensions (list (pure-tls::make-x509-extension
+                      :oid :subject-alt-name
+                      :value (mapcar (lambda (d) (list :dns d)) dns-names)))))
+
+(defun %nul-name ()
+  "The classic embedded-NUL truncation-confusion SAN: www.bank.com<NUL>.evil.com."
+  (concatenate 'string "www.bank.com" (string (code-char 0)) ".evil.com"))
+
+(test verify-hostname-embedded-nul-san-is-rejected
+  "A SAN dNSName carrying an embedded NUL must never be the basis of a match."
+  (let ((evil-name (%nul-name)))
+    ;; (a) The malicious name reaching the validator as the SAN, with the
+    ;;     truncated benign identity requested, must not match.
+    (signals pure-tls:tls-verification-error
+      (pure-tls:verify-hostname (%san-cert evil-name) "www.bank.com"))
+    ;; (b) The malicious name reaching the validator as the requested identity
+    ;;     is rejected outright as an invalid DNS name.
+    (signals pure-tls:tls-verification-error
+      (pure-tls:verify-hostname (%san-cert "www.bank.com") evil-name))))
+
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."
   (format t "~&=== Running pure-tls Security Regression Tests ===~%~%")


### PR DESCRIPTION
Follow-up #3 from #11 — a security-hardening behavior change on the
hostname-verification path.

`verify-hostname` currently compares names without a syntactic safety check, so
a name carrying an embedded NUL can reach a silent unequal compare — the classic
`www.bank.com\0.evil.com` truncation confusion, where naive C-string handling
elsewhere may treat the name as `www.bank.com`. This adds a `valid-dns-name-p`
guard applied to both the requested identity and each candidate SAN dNSName: a
name with an embedded NUL, or any byte outside the LDH set (letters, digits,
hyphen, dot), is rejected outright. A single leading `*.` wildcard label is still
permitted, so legitimate wildcard SANs continue to validate.

One behavior change to call out honestly: the requested-identity guard runs
before ASCII normalization, so a **raw U-label (non-ASCII IDN) or underscore-label
hostname is now rejected** on the `verify-hostname` path. Per RFC 6125, callers
are expected to pass already-A-label (punycode) names, and no existing test
depends on the prior behavior. If you'd rather keep U-label tolerance, I'm glad
to narrow this — e.g. reject only embedded NUL / control bytes on the requested
identity, or run the safety check after normalization. Just say which you prefer.

Includes a regression test asserting an embedded-NUL name is rejected both as a
candidate SAN and as the requested identity. Verified green against current
master (full suite 360/0).
