### PR TITLE
feat(x509): add opt-in hostname-verification policy

### DIFF
--- a/src/context-support.lisp
+++ b/src/context-support.lisp
@@ -83,3 +83,25 @@
   (if context
       (cl-cancel:close-stream-on-cancel socket context)
       (lambda () nil)))
+
+;;; Hostname-verification policy
+
+(defstruct hostname-policy
+  "Orthogonal RFC 6125 hostname-verification knobs threaded into VERIFY-HOSTNAME.
+
+   ALLOW-WILDCARDS   - When true (default), wildcard-pattern SANs (\"*.\" left
+     label) are matched per RFC 6125 via the general matcher.  When NIL, such
+     SANs are excluded from matching.
+   ALLOW-CN-FALLBACK - When true (default), a certificate carrying no
+     subjectAltName may be matched against its Subject Common Name (deprecated
+     but still widely deployed).  When NIL, identity is trusted only through the
+     subjectAltName and a no-SAN certificate is rejected outright."
+  (allow-wildcards   t)
+  (allow-cn-fallback t))
+
+(defvar *general-hostname-policy* (make-hostname-policy)
+  "The default hostname-verification policy: the general RFC 6125 profile.
+   Honors wildcard SANs via the general matcher and permits Common Name
+   fallback when no subjectAltName is present.  Preserves the library's
+   general-purpose behaviour for every caller that does not compose a stricter
+   policy.")

--- a/src/context.lisp
+++ b/src/context.lisp
@@ -28,7 +28,9 @@
   ;; ALPN protocols
   (alpn-protocols nil :type list)
   ;; Session cache (for session resumption - future)
-  (session-cache nil))
+  (session-cache nil)
+  ;; RFC 6125 hostname-verification policy threaded into VERIFY-HOSTNAME
+  (hostname-policy *general-hostname-policy* :type hostname-policy))
 
 ;;;; Default Context
 
@@ -63,7 +65,8 @@
                            ca-directory
                            cipher-suites
                            alpn-protocols
-                           (auto-load-system-ca t))
+                           (auto-load-system-ca t)
+                           (hostname-policy *general-hostname-policy*))
   "Create a new TLS context with the specified configuration.
 
    VERIFY-MODE - Certificate verification mode:
@@ -86,11 +89,16 @@
    ALPN-PROTOCOLS - List of ALPN protocol names.
 
    AUTO-LOAD-SYSTEM-CA - If T (default), automatically load system CA store
-     when verify-mode is +VERIFY-REQUIRED+ and no CA file/directory is specified."
+     when verify-mode is +VERIFY-REQUIRED+ and no CA file/directory is specified.
+
+   HOSTNAME-POLICY - HOSTNAME-POLICY value governing the RFC 6125 identity
+     decision for connections made with this context; defaults to
+     *GENERAL-HOSTNAME-POLICY* (the general profile)."
   (let ((ctx (make-tls-context-struct
               :verify-mode verify-mode
               :verify-depth verify-depth
-              :alpn-protocols alpn-protocols)))
+              :alpn-protocols alpn-protocols
+              :hostname-policy hostname-policy)))
     ;; Load certificate chain if specified
     (when certificate-chain-file
       (setf (tls-context-certificate-chain ctx)

--- a/src/handshake/client.lisp
+++ b/src/handshake/client.lisp
@@ -20,6 +20,8 @@
   (trust-store nil)
   ;; Skip hostname verification (for SNI-only hostname)
   (skip-hostname-verify nil :type boolean)
+  ;; RFC 6125 hostname-verification policy threaded into VERIFY-HOSTNAME
+  (hostname-policy *general-hostname-policy* :type hostname-policy)
   ;; Cipher suites we support (in preference order)
   ;; ChaCha20-Poly1305 is preferred when available because it provides
   ;; better side-channel resistance than AES-GCM in pure software implementations.
@@ -1622,7 +1624,7 @@
     (when (member verify-mode (list +verify-peer+ +verify-required+))
       ;; Verify hostname matches certificate (unless skip-hostname-verify is set)
       (when (and hostname (not (client-handshake-skip-hostname-verify hs)))
-        (verify-hostname cert hostname))
+        (verify-hostname cert hostname :policy (client-handshake-hostname-policy hs)))
       ;; Verify certificate chain
       ;; Pass nil for hostname when skip-hostname-verify is set to avoid
       ;; platform-specific hostname verification (macOS/Windows)
@@ -1892,7 +1894,8 @@
                                                    client-private-key
                                                    client-certificate-chain
                                                    ech-configs
-                                                   (ech-enabled t))
+                                                   (ech-enabled t)
+                                                   (hostname-policy *general-hostname-policy*))
   "Perform the TLS 1.3 client handshake.
    Returns a CLIENT-HANDSHAKE structure on success.
    TRUST-STORE is used for certificate chain verification when verify-mode is +verify-required+.
@@ -1907,6 +1910,7 @@
              :verify-mode verify-mode
              :trust-store trust-store
              :skip-hostname-verify skip-hostname-verify
+             :hostname-policy hostname-policy
              :client-certificate client-certificate
              :client-private-key client-private-key
              :client-certificate-chain client-certificate-chain

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -47,6 +47,13 @@
    #:certificate-free
    #:verify-hostname
 
+   ;; Hostname-verification policy
+   #:hostname-policy
+   #:make-hostname-policy
+   #:hostname-policy-allow-wildcards
+   #:hostname-policy-allow-cn-fallback
+   #:*general-hostname-policy*
+
    ;; Crypto utilities
    #:random-bytes
    #:constant-time-equal

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -586,7 +586,8 @@
                   :client-private-key private-key
                   :client-certificate-chain chain-certs
                   :ech-configs parsed-ech-configs
-                  :ech-enabled ech-enabled)))
+                  :ech-enabled ech-enabled
+                  :hostname-policy (tls-context-hostname-policy context))))
         (setf (tls-stream-handshake stream) hs)
         ;; Verify certificate chain and hostname if verification enabled
         (when (and (member verify (list +verify-peer+ +verify-required+))
@@ -595,7 +596,7 @@
                 (chain (client-handshake-peer-certificate-chain hs)))
             ;; Verify hostname - only if hostname (not just sni-hostname) was provided
             (when hostname
-              (verify-hostname cert hostname))
+              (verify-hostname cert hostname :policy (tls-context-hostname-policy context)))
             ;; Verify certificate chain for both +verify-peer+ and +verify-required+
             ;; (+verify-peer+ means "verify if presented" - servers always present certs)
             (when chain

--- a/src/x509/verify.lisp
+++ b/src/x509/verify.lisp
@@ -32,10 +32,28 @@
                           (char= c #\-)
                           (char= c #\.))))))
 
-(defun verify-hostname (cert hostname)
-  "Verify that HOSTNAME matches the certificate.
+(defun wildcard-pattern-p (name)
+  "Return T if NAME is a wildcard-pattern SAN: a leading \"*.\" label.  Used to
+   optionally exclude wildcard SANs from matching when a policy disables
+   ALLOW-WILDCARDS; the general RFC 6125 matcher itself is left untouched."
+  (and (stringp name)
+       (>= (length name) 2)
+       (char= (char name 0) #\*)
+       (char= (char name 1) #\.)))
+
+(defun verify-hostname (cert hostname &key (policy *general-hostname-policy*))
+  "Verify that HOSTNAME matches the certificate CERT under POLICY.
    Supports both DNS hostnames and IP address literals.
-   Returns T if verification succeeds, signals TLS-VERIFICATION-ERROR otherwise."
+   Returns T if verification succeeds, signals TLS-VERIFICATION-ERROR otherwise.
+
+   POLICY is a HOSTNAME-POLICY value; the default *GENERAL-HOSTNAME-POLICY* is
+   the RFC 6125 general profile.  Two orthogonal knobs shape the identity
+   decision: ALLOW-WILDCARDS gates whether wildcard-pattern SANs participate in
+   matching (the general matcher applies the RFC 6125 wildcard rules), and
+   ALLOW-CN-FALLBACK gates whether a certificate carrying no subjectAltName may
+   be matched against its Subject Common Name.  Embedded-NUL / non-LDH name
+   safety and IP-literal handling are pure correctness and apply under every
+   policy."
   ;; Check if hostname is an IP address literal
   (let ((ip-bytes (parse-ip-address hostname)))
     (when ip-bytes
@@ -57,16 +75,21 @@
            :hostname hostname
            :message "Requested hostname is not a valid DNS name (embedded NUL or non-LDH byte)"))
 
-  ;; DNS hostname - check Subject Alternative Name extension first
+  ;; DNS hostname - check Subject Alternative Name extension first.  When a SAN
+  ;; is present the Common Name is not consulted (RFC 6125).  A wildcard-pattern
+  ;; SAN participates only when the policy allows wildcards; otherwise it is
+  ;; skipped and the general matcher applies the RFC 6125 wildcard rules to the
+  ;; remaining SANs.
   (let ((san-names (certificate-dns-names cert))
         (san-ips (certificate-ip-addresses cert)))
     (when (or san-names san-ips)
-      ;; If SAN is present, only use SAN (ignore CN per RFC 6125)
       (if (some (lambda (san-name)
                   ;; A SAN dNSName still malformed after IDNA normalization
                   ;; (embedded NUL / non-LDH byte) can never be the basis of
                   ;; a match; skip it before comparing.
                   (and (valid-dns-name-p (normalize-hostname-to-ascii san-name))
+                       (or (hostname-policy-allow-wildcards policy)
+                           (not (wildcard-pattern-p san-name)))
                        (hostname-matches-p san-name hostname)))
                 san-names)
           (return-from verify-hostname t)
@@ -74,16 +97,19 @@
                  :hostname hostname
                  :message "Hostname does not match any SAN entry"))))
 
-  ;; Fall back to Common Name if no SAN (deprecated but still supported)
-  (let ((cns (certificate-subject-common-names cert)))
-    (when cns
-      (if (some (lambda (cn)
-                  (hostname-matches-p cn hostname))
-                cns)
-          (return-from verify-hostname t)
-          (error 'tls-verification-error
-                 :hostname hostname
-                 :message "Hostname does not match certificate CN"))))
+  ;; Fall back to Common Name if no SAN (deprecated but still supported), when
+  ;; the policy permits it.  With CN fallback disabled a no-SAN certificate
+  ;; carries no acceptable identity and is rejected.
+  (when (hostname-policy-allow-cn-fallback policy)
+    (let ((cns (certificate-subject-common-names cert)))
+      (when cns
+        (if (some (lambda (cn)
+                    (hostname-matches-p cn hostname))
+                  cns)
+            (return-from verify-hostname t)
+            (error 'tls-verification-error
+                   :hostname hostname
+                   :message "Hostname does not match certificate CN")))))
 
   ;; No SAN or CN to check
   (error 'tls-verification-error
@@ -780,7 +806,8 @@ TRUST-ANCHOR-MODE controls how trusted-roots interact with system store:
 (defun verify-peer-certificate (cert hostname &key
                                                verify-mode
                                                trust-store
-                                               (check-dates t))
+                                               (check-dates t)
+                                               (hostname-policy *general-hostname-policy*))
   "Perform full verification of a peer certificate.
 
    CERT - The certificate to verify.
@@ -788,6 +815,8 @@ TRUST-ANCHOR-MODE controls how trusted-roots interact with system store:
    VERIFY-MODE - One of +VERIFY-NONE+, +VERIFY-PEER+, or +VERIFY-REQUIRED+.
    TRUST-STORE - Trust store for chain verification (optional).
    CHECK-DATES - Whether to check validity dates (default T).
+   HOSTNAME-POLICY - HOSTNAME-POLICY value governing the RFC 6125 identity
+     decision; defaults to *GENERAL-HOSTNAME-POLICY* (the general profile).
 
    Returns T on success, signals appropriate error on failure."
   ;; Skip if verification disabled
@@ -798,7 +827,7 @@ TRUST-ANCHOR-MODE controls how trusted-roots interact with system store:
     (verify-certificate-dates cert))
   ;; Verify hostname
   (when hostname
-    (verify-hostname cert hostname))
+    (verify-hostname cert hostname :policy hostname-policy))
   ;; Chain verification (if trust store provided)
   (when trust-store
     (let ((issuer (trust-store-find-issuer trust-store cert)))

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -630,6 +630,12 @@
                       :oid :subject-alt-name
                       :value (mapcar (lambda (d) (list :dns d)) dns-names)))))
 
+(defun %cn-only-cert (common-name)
+  "Build a certificate with a Subject Common Name and NO subjectAltName."
+  (pure-tls::make-x509-certificate
+   :subject (pure-tls::make-x509-name
+             :rdns (list (cons :common-name common-name)))))
+
 (defun %nul-name ()
   "The classic embedded-NUL truncation-confusion SAN: www.bank.com<NUL>.evil.com."
   (concatenate 'string "www.bank.com" (string (code-char 0)) ".evil.com"))
@@ -653,6 +659,55 @@
   (let ((u-label (format nil "m~Cnchen.example.com" (code-char 252)))) ; münchen
     (is-true (pure-tls:verify-hostname
               (%san-cert "xn--mnchen-3ya.example.com") u-label))))
+
+;;;; ---------------------------------------------------------------------------
+;;;; Hostname-verification policy: two orthogonal RFC 6125 knobs on the TLS
+;;;; context, both defaulting to the permissive value so the default profile is
+;;;; byte-for-byte the general-purpose behaviour.  ALLOW-WILDCARDS gates whether
+;;;; wildcard SANs match; ALLOW-CN-FALLBACK gates Common Name fallback for a
+;;;; no-SAN certificate.
+;;;; ---------------------------------------------------------------------------
+
+(test verify-hostname-default-honors-wildcard-san
+  "The default policy honors an RFC 6125 wildcard SAN: *.example.com must
+   authenticate www.example.com when no explicit policy is supplied."
+  (is (pure-tls:verify-hostname (%san-cert "*.example.com") "www.example.com")
+      "A wildcard SAN must authenticate a single-label host under the default policy"))
+
+(test verify-hostname-allow-wildcards-nil-excludes-wildcard-san
+  "With ALLOW-WILDCARDS disabled, a wildcard SAN is excluded from matching even
+   where the general matcher would cover it, while an exact SAN still matches."
+  (let ((policy (pure-tls:make-hostname-policy :allow-wildcards nil)))
+    (signals pure-tls:tls-verification-error
+      (pure-tls:verify-hostname (%san-cert "*.example.com") "foo.example.com"
+                                :policy policy))
+    (is (pure-tls:verify-hostname (%san-cert "dns.google") "dns.google"
+                                  :policy policy)
+        "An exact SAN must still match when wildcards are disabled")))
+
+(test verify-hostname-default-permits-cn-fallback
+  "The default policy falls back to the Subject Common Name for a no-SAN
+   certificate (deprecated but still deployed)."
+  (is (pure-tls:verify-hostname (%cn-only-cert "www.example.com")
+                                "www.example.com")
+      "CN fallback must authenticate a matching no-SAN certificate by default"))
+
+(test verify-hostname-allow-cn-fallback-nil-rejects-no-san
+  "With ALLOW-CN-FALLBACK disabled the Common Name is never consulted, so a
+   no-SAN certificate is rejected even when its CN matches exactly."
+  (let ((policy (pure-tls:make-hostname-policy :allow-cn-fallback nil)))
+    (signals pure-tls:tls-verification-error
+      (pure-tls:verify-hostname (%cn-only-cert "www.example.com")
+                                "www.example.com"
+                                :policy policy))))
+
+(test hostname-policy-general-matcher-unchanged
+  "The general RFC 6125 wildcard matcher is untouched by the policy seam: a
+   single-label wildcard still matches structurally, *.com does not, and a
+   wildcard over a multi-label public suffix does not."
+  (is (pure-tls::hostname-matches-p "*.example.com" "foo.example.com"))
+  (is (not (pure-tls::hostname-matches-p "*.com" "foo.com")))
+  (is (not (pure-tls::hostname-matches-p "*.co.uk" "foo.co.uk"))))
 
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."


### PR DESCRIPTION
Implements the opt-in from #15, in the orthogonal-knobs shape you preferred.

## What

`verify-hostname` now accepts a `hostname-policy` carried on the TLS context,
exposing two orthogonal RFC 6125 knobs on `make-tls-context`:

- **`allow-wildcards`** — when `nil`, wildcard-pattern (`*.`) SANs are excluded
  from matching. The general RFC 6125 matcher (`hostname-matches-p` /
  `wildcard-hostname-matches-p`) is left untouched; a disabled policy simply
  skips wildcard SANs before they reach it.
- **`allow-cn-fallback`** — when `nil`, identity is trusted only through the
  subjectAltName; a certificate carrying no SAN is rejected rather than matched
  against its Subject Common Name.

Both default to the permissive value, so `*general-hostname-policy*` — the
context default — **preserves current behaviour byte-for-byte**. Existing
callers see no change; the knobs are purely additive.

A consumer that authenticates a single specific name selects a stricter
composition at the context:

```lisp
(make-tls-context :verify-mode +verify-required+
                  :hostname-policy (make-hostname-policy :allow-wildcards nil
                                                         :allow-cn-fallback nil))
```

## Why

Per the discussion in #15: some callers authenticate one specific server name
and would rather refuse wildcards and CN-only certs, but neither refusal is
right as a library default — the general web relies on both. An opt-in on the
context keeps the default general and lets those callers tighten locally.

## Notes for review

- Embedded-NUL / non-LDH name safety and IP-literal handling remain
  unconditional under every policy — they are correctness, not policy.
- The policy value threads through the same path as `skip-hostname-verify`
  (`streams` → `perform-client-handshake` → `verify-hostname`), plus a
  `:hostname-policy` key on the public `verify-peer-certificate`.
- Tests (in `test/security-regression-tests.lisp`) prove each knob
  independently, the permissive default for both, and that the general matcher
  is unchanged by the seam. Full unit suite green locally on 1.12.0.

No new dependencies; MIT, same as the rest of the tree.