### PR TITLE
Recover from transient ACME HTTP errors (badNonce, rate-limit, not-ready) via the condition system

### DIFF
--- a/acme/acme-client.lisp
+++ b/acme/acme-client.lisp
@@ -69,75 +69,278 @@
 ;;; HTTP Operations (client-scoped)
 ;;; ----------------------------------------------------------------------------
 
+;;; ----------------------------------------------------------------------------
+;;; HTTP request seam and retry infrastructure
+;;;
+;;; All ACME HTTP traffic flows through CLIENT-HTTP-REQUEST, which calls the
+;;; pluggable *HTTP-REQUEST-FUNCTION* (default DRAKMA:HTTP-REQUEST). Recoverable
+;;; responses are mapped onto typed conditions and offered a RETRY restart, so a
+;;; policy handler (WITH-ACME-RETRIES) can re-drive the request in place. Waiting
+;;; goes through *SLEEP-FUNCTION* so tests can drive Retry-After paths with no
+;;; real delay.
+;;; ----------------------------------------------------------------------------
+
+(defparameter *http-request-function* 'drakma:http-request
+  "Function used to perform HTTP requests. Called as
+   (funcall *http-request-function* url &key method content content-type accept)
+   and must return (values body status headers) like DRAKMA:HTTP-REQUEST.
+   Rebindable so tests can stub the network layer.")
+
+(defparameter *sleep-function* #'sleep
+  "Function called to wait between retries, as (funcall *sleep-function* seconds).
+   Rebindable so tests can exercise Retry-After paths without real sleeping.")
+
+(defparameter *default-retry-after* 1
+  "Fallback delay in seconds when a recoverable response carries no usable
+   Retry-After header.")
+
+(defparameter +acme-error-bad-nonce+ "urn:ietf:params:acme:error:badNonce"
+  "RFC 8555 problem document type for a rejected nonce.")
+
+(defparameter +acme-error-rate-limited+ "urn:ietf:params:acme:error:rateLimited"
+  "RFC 8555 problem document type for a rate-limited request.")
+
+(defun ensure-body-string (body)
+  "Return BODY as a string, decoding octet vectors as UTF-8."
+  (if (stringp body)
+      body
+      (flexi-streams:octets-to-string body :external-format :utf-8)))
+
+(defun decode-acme-body (body-str)
+  "Decode a non-empty ACME JSON BODY-STR into an alist, or NIL when empty."
+  (when (and body-str (> (length body-str) 0))
+    (cl-json:decode-json-from-string body-str)))
+
+(defun acme-problem-doc (body-str)
+  "Parse BODY-STR as an RFC 7807 problem document, returning the decoded alist,
+   or NIL when it is empty or not a JSON object. Never signals on malformed
+   input."
+  (let ((trimmed (and body-str
+                      (string-left-trim '(#\Space #\Newline #\Return #\Tab)
+                                        body-str))))
+    (when (and trimmed (> (length trimmed) 0) (char= (char trimmed 0) #\{))
+      (ignore-errors (cl-json:decode-json-from-string trimmed)))))
+
+(defun parse-retry-after (headers)
+  "Return the Retry-After header from HEADERS in seconds as a non-negative
+   integer, or NIL when absent or in the HTTP-date form (which callers treat as
+   'use the default delay')."
+  (let ((raw (rest (assoc :retry-after headers))))
+    (when raw
+      (let* ((text (string-trim '(#\Space #\Tab #\Return #\Newline)
+                                (princ-to-string raw)))
+             (seconds (ignore-errors (parse-integer text :junk-allowed nil))))
+        (when (and (integerp seconds) (>= seconds 0))
+          seconds)))))
+
+(defun recoverable-acme-condition (status problem)
+  "Return the condition class name for a recoverable response, or NIL for a
+   success or terminal (non-recoverable) response.
+   STATUS is the HTTP status; PROBLEM is the decoded problem document or NIL."
+  (let ((type (and (consp problem) (rest (assoc :type problem)))))
+    (cond
+      ((and (integerp status) (<= 400 status 499)
+            type (string= type +acme-error-bad-nonce+))
+       'acme-bad-nonce)
+      ((or (eql status 429)
+           (and type (string= type +acme-error-rate-limited+)))
+       'acme-rate-limited)
+      ((eql status 202)
+       'acme-not-ready)
+      (t nil))))
+
+(defun client-http-request (client url method builder)
+  "Perform a single ACME HTTP request and expose recovery via a RETRY restart.
+
+   BUILDER is a thunk returning the plist of keyword arguments passed to
+   *HTTP-REQUEST-FUNCTION* (for example (:method :post :content ...)). For a
+   signed POST, BUILDER re-signs the JWS with CLIENT's current nonce each time
+   it runs, so re-invoking it after a nonce refresh yields a correctly-signed
+   retry. The Replay-Nonce returned by the server is captured into CLIENT before
+   any recoverable condition is signalled.
+
+   When the response is recoverable (badNonce, 429/rateLimited, 202/not-ready)
+   the matching typed condition is SIGNALLED inside a RESTART-CASE whose RETRY
+   restart re-drives this same request. If no handler invokes RETRY (none
+   established, or the retry budget is exhausted) SIGNAL returns normally and the
+   response is returned as-is, preserving the pre-retry behaviour.
+
+   Returns (values body-string status headers)."
+  (restart-case
+      (multiple-value-bind (body status headers)
+          (apply *http-request-function* url (funcall builder))
+        (let ((body-str (ensure-body-string body))
+              (nonce (rest (assoc :replay-nonce headers))))
+          (when nonce
+            (setf (acme-client-nonce client) nonce))
+          (let* ((problem (when (or (eql status 202)
+                                    (and (integerp status) (>= status 400)))
+                            (acme-problem-doc body-str)))
+                 (class (recoverable-acme-condition status problem)))
+            (when class
+              (signal class
+                      :status status
+                      :problem problem
+                      :headers headers
+                      :url url
+                      :method method
+                      :retry-after (parse-retry-after headers))))
+          (values body-str status headers)))
+    (retry ()
+      :report "Refresh ACME state and retry this request."
+      (client-http-request client url method builder))))
+
+(defun call-with-acme-retries (thunk &key (max-nonce-retries 3)
+                                          (max-retry-after-attempts 10)
+                                          (max-total-wait 120)
+                                          (handle-not-ready t))
+  "Call THUNK with ACME recovery handlers established (see WITH-ACME-RETRIES).
+
+   A badNonce condition is retried up to MAX-NONCE-RETRIES times, re-signing with
+   the nonce the server returned in the rejecting response. A rate-limited
+   condition (and, when HANDLE-NOT-READY, a not-ready condition) waits per
+   Retry-After through *SLEEP-FUNCTION* and retries, bounded by both
+   MAX-RETRY-AFTER-ATTEMPTS and MAX-TOTAL-WAIT seconds. When a budget is
+   exhausted the handler declines and the condition propagates or the response
+   is returned as-is, so recovery is always bounded and never loops forever."
+  (let ((nonce-retries 0)
+        (wait-attempts 0)
+        (total-wait 0))
+    (labels ((do-retry (condition)
+               (let ((restart (find-restart 'retry condition)))
+                 (when restart
+                   (invoke-restart restart))))
+             (on-bad-nonce (condition)
+               (when (< nonce-retries max-nonce-retries)
+                 (incf nonce-retries)
+                 (do-retry condition)))
+             (on-wait (condition)
+               (let ((wait (or (acme-http-error-retry-after condition)
+                               *default-retry-after*)))
+                 (when (and (< wait-attempts max-retry-after-attempts)
+                            (<= (+ total-wait wait) max-total-wait))
+                   (incf wait-attempts)
+                   (incf total-wait wait)
+                   (funcall *sleep-function* wait)
+                   (do-retry condition)))))
+      (if handle-not-ready
+          (handler-bind ((acme-bad-nonce #'on-bad-nonce)
+                         (acme-rate-limited #'on-wait)
+                         (acme-not-ready #'on-wait))
+            (funcall thunk))
+          (handler-bind ((acme-bad-nonce #'on-bad-nonce)
+                         (acme-rate-limited #'on-wait))
+            (funcall thunk))))))
+
+(defmacro with-acme-retries ((&key (max-nonce-retries 3)
+                                   (max-retry-after-attempts 10)
+                                   (max-total-wait 120)
+                                   (handle-not-ready t))
+                             &body body)
+  "Evaluate BODY with ACME request-level recovery established around every
+   request it issues. Recoverable ACME responses are handled without unwinding
+   the stack: each is mapped onto a RETRY restart that re-drives the offending
+   request. See CALL-WITH-ACME-RETRIES for the budget parameters. Exposed so an
+   issuance driver can wrap a broader region under one policy; the public client
+   functions already establish sensible defaults for standalone calls."
+  `(call-with-acme-retries
+    (lambda () ,@body)
+    :max-nonce-retries ,max-nonce-retries
+    :max-retry-after-attempts ,max-retry-after-attempts
+    :max-total-wait ,max-total-wait
+    :handle-not-ready ,handle-not-ready))
+
 (defun client-get (client url)
-  "GET request to ACME endpoint."
-  (let ((cl+ssl:*make-ssl-client-stream-verify-default*
-          (if (acme-client-skip-tls-verify client)
-              nil
-              cl+ssl:*make-ssl-client-stream-verify-default*)))
-    (multiple-value-bind (body status headers)
-        (drakma:http-request url :method :get)
-      (let ((nonce (rest (assoc :replay-nonce headers)))
-            (body-str (if (stringp body)
-                          body
-                          (flexi-streams:octets-to-string body :external-format :utf-8))))
-        (when nonce
-          (setf (acme-client-nonce client) nonce))
-        (values (when (> (length body-str) 0)
-                  (cl-json:decode-json-from-string body-str))
-                status)))))
-
-(defun client-post (client url payload &key use-kid)
-  "POST request with JWS body to ACME endpoint.
-   USE-KID: Use account URL (kid) instead of JWK in header."
-  ;; Get fresh nonce if needed
-  (unless (acme-client-nonce client)
-    (client-get client (rest (assoc :new-nonce (acme-client-directory client)))))
-
-  (let* ((account-key (acme-client-account-key client))
-         (protected-header
-           (if use-kid
-               `(("alg" . "ES256")
-                 ("kid" . ,(acme-client-account-url client))
-                 ("nonce" . ,(acme-client-nonce client))
-                 ("url" . ,url))
-               `(("alg" . "ES256")
-                 ("jwk" . ,(get-public-key-jwk account-key))
-                 ("nonce" . ,(acme-client-nonce client))
-                 ("url" . ,url))))
-         (protected64 (base64url-encode
-                       (cl-json:encode-json-to-string protected-header)))
-         (payload64 (if payload
-                        (base64url-encode
-                         (cl-json:encode-json-to-string payload))
-                        ""))
-         (signature (sign-payload account-key
-                                  (format nil "~A.~A" protected64 payload64)))
-         (jws `(("protected" . ,protected64)
-                ("payload" . ,payload64)
-                ("signature" . ,signature))))
-
-    (setf (acme-client-nonce client) nil)  ; Nonce is single-use
-
+  "GET request to ACME endpoint.
+   Returns (VALUES decoded-body status). A rate-limited response is retried per
+   Retry-After; the return contract is unchanged for success and terminal
+   responses."
+  (with-acme-retries (:handle-not-ready nil)
     (let ((cl+ssl:*make-ssl-client-stream-verify-default*
             (if (acme-client-skip-tls-verify client)
                 nil
                 cl+ssl:*make-ssl-client-stream-verify-default*)))
-      (multiple-value-bind (body status headers)
-          (drakma:http-request url
-                               :method :post
-                               :content-type "application/jose+json"
-                               :content (cl-json:encode-json-to-string jws))
-        (let* ((nonce (rest (assoc :replay-nonce headers)))
-               (location (rest (assoc :location headers)))
-               (body-str (if (stringp body)
-                             body
-                             (flexi-streams:octets-to-string body :external-format :utf-8))))
-          (when nonce (setf (acme-client-nonce client) nonce))
-          (values (when (> (length body-str) 0)
-                    (cl-json:decode-json-from-string body-str))
-                  status
-                  location))))))
+      (multiple-value-bind (body-str status headers)
+          (client-http-request client url :get
+                               (lambda () (list :method :get)))
+        (declare (ignore headers))
+        (values (decode-acme-body body-str) status)))))
+
+(defun client-ensure-nonce (client)
+  "Ensure CLIENT holds a usable nonce, fetching a fresh one from the directory's
+   new-nonce endpoint when needed. Returns the current nonce."
+  (unless (acme-client-nonce client)
+    (client-get client (rest (assoc :new-nonce (acme-client-directory client)))))
+  (acme-client-nonce client))
+
+(defun make-jws-post-builder (client url payload &key use-kid accept)
+  "Return a thunk producing the request keyword arguments for a signed ACME POST
+   to URL with PAYLOAD. Each call ensures a nonce, builds and signs the JWS with
+   CLIENT's current nonce, then clears the nonce (single-use). Because it
+   re-signs on every call, invoking it again after a nonce refresh produces a
+   correctly-signed retry.
+   USE-KID selects the account URL (kid) header instead of the JWK; ACCEPT, when
+   supplied, sets the request's Accept header."
+  (lambda ()
+    (client-ensure-nonce client)
+    (let* ((account-key (acme-client-account-key client))
+           (protected-header
+             (if use-kid
+                 `(("alg" . "ES256")
+                   ("kid" . ,(acme-client-account-url client))
+                   ("nonce" . ,(acme-client-nonce client))
+                   ("url" . ,url))
+                 `(("alg" . "ES256")
+                   ("jwk" . ,(get-public-key-jwk account-key))
+                   ("nonce" . ,(acme-client-nonce client))
+                   ("url" . ,url))))
+           (protected64 (base64url-encode
+                         (cl-json:encode-json-to-string protected-header)))
+           (payload64 (if payload
+                          (base64url-encode
+                           (cl-json:encode-json-to-string payload))
+                          ""))
+           (signature (sign-payload account-key
+                                    (format nil "~A.~A" protected64 payload64)))
+           (jws `(("protected" . ,protected64)
+                  ("payload" . ,payload64)
+                  ("signature" . ,signature))))
+      (setf (acme-client-nonce client) nil)  ; Nonce is single-use
+      (append (list :method :post
+                    :content-type "application/jose+json"
+                    :content (cl-json:encode-json-to-string jws))
+              (when accept (list :accept accept))))))
+
+(defun perform-client-post (client url payload &key use-kid accept
+                                                    (handle-not-ready t))
+  "Issue a signed ACME POST to URL with request-level retry recovery, returning
+   (values body-string status headers). badNonce and rate-limited responses are
+   always retried; a 202/not-ready response is retried only when
+   HANDLE-NOT-READY is true. Callers that own their own readiness polling
+   (poll-status, finalize) pass HANDLE-NOT-READY NIL so a 202 is returned as-is
+   rather than waited on a second time."
+  (with-acme-retries (:handle-not-ready handle-not-ready)
+    (let ((cl+ssl:*make-ssl-client-stream-verify-default*
+            (if (acme-client-skip-tls-verify client)
+                nil
+                cl+ssl:*make-ssl-client-stream-verify-default*)))
+      (client-http-request client url :post
+                           (make-jws-post-builder client url payload
+                                                  :use-kid use-kid
+                                                  :accept accept)))))
+
+(defun client-post (client url payload &key use-kid)
+  "POST request with JWS body to ACME endpoint.
+   USE-KID: Use account URL (kid) instead of JWK in header.
+   Returns (VALUES decoded-body status location). A badNonce or rate-limited
+   response self-heals (refresh nonce / wait per Retry-After and retry); the
+   return contract is unchanged for success and terminal responses."
+  (multiple-value-bind (body-str status headers)
+      (perform-client-post client url payload :use-kid use-kid
+                                              :handle-not-ready nil)
+    (values (decode-acme-body body-str)
+            status
+            (rest (assoc :location headers)))))
 
 ;;; ----------------------------------------------------------------------------
 ;;; ACME Protocol Operations
@@ -208,78 +411,74 @@
 
 (defun client-poll-status (client url &key (max-attempts 30) (delay 2) wait-for-valid)
   "Poll order/authorization status until ready or failed.
-   Returns (VALUES response status-keyword)."
+   Returns (VALUES response status-keyword).
+
+   This is the poll primitive an issuance driver calls to wait for readiness; it
+   is a single loop and never establishes a nested readiness wait. A non-string
+   :status (for example a problem document's numeric status) is treated as
+   non-terminal: wait and poll again rather than comparing it as a string. When
+   the response carries a Retry-After header its value sets this loop's sleep
+   interval; otherwise DELAY is used. Waiting goes through *SLEEP-FUNCTION*."
   (client-log client :debug "Polling status: ~A" url)
   (loop for attempt from 1 to max-attempts
-        do (multiple-value-bind (response status)
-               (client-post client url nil :use-kid t)
+        do (multiple-value-bind (body-str status headers)
+               (perform-client-post client url nil :use-kid t
+                                                   :handle-not-ready nil)
              (declare (ignore status))
-             (let ((state (rest (assoc :status response))))
+             (let* ((response (decode-acme-body body-str))
+                    (state (rest (assoc :status response)))
+                    (wait (or (parse-retry-after headers) delay)))
                (client-log client :debug "Poll ~A/~A: ~A" attempt max-attempts state)
                (cond
+                 ((not (stringp state))
+                  (funcall *sleep-function* wait))
                  ((string= state "valid")
                   (return (values response :valid)))
                  ((string= state "ready")
                   (if wait-for-valid
-                      (sleep delay)
+                      (funcall *sleep-function* wait)
                       (return (values response :ready))))
                  ((string= state "processing")
-                  (sleep delay))
+                  (funcall *sleep-function* wait))
                  ((string= state "invalid")
                   (return (values response :invalid)))
                  ((string= state "pending")
-                  (sleep delay))
-                 (t (sleep delay)))))
+                  (funcall *sleep-function* wait))
+                 (t (funcall *sleep-function* wait)))))
         finally (return (values nil :timeout))))
 
 (defun client-finalize-order (client finalize-url csr-der)
-  "Submit CSR to finalize the order."
+  "Submit CSR to finalize the order.
+   Returns (VALUES response status location). badNonce and rate-limited
+   responses self-heal; a 202/processing finalize response is returned as-is,
+   since order readiness is the caller's responsibility (poll the order to
+   :valid), not a second client-side wait."
   (client-log client :info "Finalizing order")
-  (client-post client finalize-url
-               `(("csr" . ,(base64url-encode csr-der)))
-               :use-kid t))
+  (multiple-value-bind (body-str status headers)
+      (perform-client-post client finalize-url
+                           `(("csr" . ,(base64url-encode csr-der)))
+                           :use-kid t :handle-not-ready nil)
+    (values (decode-acme-body body-str)
+            status
+            (rest (assoc :location headers)))))
 
 (defun client-download-certificate (client cert-url)
-  "Download the issued certificate chain (returns PEM string)."
-  ;; Get fresh nonce first
-  (unless (acme-client-nonce client)
-    (client-get client (rest (assoc :new-nonce (acme-client-directory client)))))
+  "Download the issued certificate chain (returns PEM string).
 
-  (let* ((account-key (acme-client-account-key client))
-         (protected-header
-           `(("alg" . "ES256")
-             ("kid" . ,(acme-client-account-url client))
-             ("nonce" . ,(acme-client-nonce client))
-             ("url" . ,cert-url)))
-         (protected64 (base64url-encode
-                       (cl-json:encode-json-to-string protected-header)))
-         (payload64 "")
-         (signature (sign-payload account-key
-                                  (format nil "~A.~A" protected64 payload64)))
-         (jws `(("protected" . ,protected64)
-                ("payload" . ,payload64)
-                ("signature" . ,signature))))
-
-    (setf (acme-client-nonce client) nil)
-
-    (let ((cl+ssl:*make-ssl-client-stream-verify-default*
-            (if (acme-client-skip-tls-verify client)
-                nil
-                cl+ssl:*make-ssl-client-stream-verify-default*)))
-      (multiple-value-bind (body status headers)
-          (drakma:http-request cert-url
-                               :method :post
-                               :content-type "application/jose+json"
-                               :accept "application/pem-certificate-chain"
-                               :content (cl-json:encode-json-to-string jws))
-        (let ((nonce (rest (assoc :replay-nonce headers)))
-              (body-str (if (stringp body)
-                            body
-                            (flexi-streams:octets-to-string body :external-format :utf-8))))
-          (when nonce (setf (acme-client-nonce client) nonce))
-          (if (= status 200)
-              body-str
-              nil))))))
+   A 202/not-ready response is retried per Retry-After until the chain is
+   available, then the PEM is returned. This is the request-level readiness wait
+   the client owns for its own download path. Returns the PEM string on HTTP 200,
+   or NIL for a terminal non-200 (unchanged from the pre-retry contract), which
+   only occurs once retries are exhausted or the failure is non-recoverable."
+  (multiple-value-bind (body-str status headers)
+      (perform-client-post client cert-url nil
+                           :use-kid t
+                           :accept "application/pem-certificate-chain"
+                           :handle-not-ready t)
+    (declare (ignore headers))
+    (if (= status 200)
+        body-str
+        nil)))
 
 (defun client-compute-key-authorization (client token)
   "Compute key authorization: token.thumbprint"

--- a/acme/client.lisp
+++ b/acme/client.lisp
@@ -46,6 +46,53 @@
 (define-condition acme-certificate-error (acme-error) ())
 
 ;;; ----------------------------------------------------------------------------
+;;; HTTP-level conditions (recoverable via restarts)
+;;;
+;;; These map ACME HTTP responses onto typed conditions. A policy handler
+;;; (see WITH-ACME-RETRIES) turns each recoverable condition into a RETRY
+;;; restart that re-drives the offending request, without unwinding the stack.
+;;; ----------------------------------------------------------------------------
+
+(define-condition acme-http-error (acme-error)
+  ((status :initarg :status :initform nil :reader acme-http-error-status
+           :documentation "HTTP status code of the offending response.")
+   (problem :initarg :problem :initform nil :reader acme-http-error-problem
+            :documentation "Decoded RFC 7807 problem document alist, or NIL.")
+   (headers :initarg :headers :initform nil :reader acme-http-error-headers
+            :documentation "Response headers alist.")
+   (url :initarg :url :initform nil :reader acme-http-error-url
+        :documentation "URL of the request that produced this response.")
+   (method :initarg :method :initform nil :reader acme-http-error-method
+           :documentation "HTTP method keyword of the request (:get / :post).")
+   (retry-after :initarg :retry-after :initform nil :reader acme-http-error-retry-after
+                :documentation "Parsed Retry-After delay in seconds, or NIL."))
+  (:default-initargs :message "ACME HTTP error")
+  (:report
+   (lambda (condition stream)
+     (format stream "ACME HTTP ~A error for ~A ~A~@[: ~A~]"
+             (acme-http-error-status condition)
+             (acme-http-error-method condition)
+             (acme-http-error-url condition)
+             (let ((problem (acme-http-error-problem condition)))
+               (and (consp problem) (rest (assoc :detail problem)))))))
+  (:documentation "Base condition for a recoverable ACME HTTP response."))
+
+(define-condition acme-bad-nonce (acme-http-error) ()
+  (:documentation
+   "The ACME server rejected the request nonce (error type badNonce).
+    Recoverable: refresh the nonce and retry the request."))
+
+(define-condition acme-not-ready (acme-http-error) ()
+  (:documentation
+   "The requested ACME resource is not yet ready (e.g. HTTP 202 Accepted).
+    Recoverable: wait per Retry-After and retry the request."))
+
+(define-condition acme-rate-limited (acme-http-error) ()
+  (:documentation
+   "The ACME server rate-limited the request (HTTP 429 or error type
+    rateLimited). Recoverable: wait per Retry-After and retry the request."))
+
+;;; ----------------------------------------------------------------------------
 ;;; Base64URL encoding (ACME requires this, not standard base64)
 ;;; ----------------------------------------------------------------------------
 

--- a/acme/package.lisp
+++ b/acme/package.lisp
@@ -53,4 +53,17 @@
    #:acme-error
    #:acme-challenge-error
    #:acme-order-error
-   #:acme-certificate-error))
+   #:acme-certificate-error
+   #:acme-http-error
+   #:acme-bad-nonce
+   #:acme-not-ready
+   #:acme-rate-limited
+   #:acme-http-error-status
+   #:acme-http-error-problem
+   #:acme-http-error-headers
+   #:acme-http-error-url
+   #:acme-http-error-method
+   #:acme-http-error-retry-after
+
+   ;; Retry policy (for issuance drivers)
+   #:with-acme-retries))

--- a/pure-tls.asd
+++ b/pure-tls.asd
@@ -139,3 +139,14 @@
                              (:file "security-regression-tests")
                              (:file "resumption-interop-tests")
                              (:file "runner")))))
+
+(asdf:defsystem "pure-tls/acme/test"
+  :description "Tests for the pure-tls ACME client retry/restart handling"
+  :author "Anthony Green <green@moxielogic.com>"
+  :license "MIT"
+  :depends-on ("pure-tls/acme"
+               "fiveam")
+  :serial t
+  :components ((:module "test/acme"
+                :serial t
+                :components ((:file "client-retry-tests")))))

--- a/test/acme/client-retry-tests.lisp
+++ b/test/acme/client-retry-tests.lisp
@@ -1,0 +1,236 @@
+;;; test/acme/client-retry-tests.lisp --- ACME client retry/restart tests
+;;;
+;;; SPDX-License-Identifier: MIT
+;;;
+;;; Copyright (C) 2026 Anthony Green <green@moxielogic.com>
+;;;
+;;; Exercises the condition/restart retry layer of the ACME client with a
+;;; stubbed HTTP transport and a no-op sleep, so recoverable ACME responses
+;;; (badNonce, 202/not-ready, 429/rateLimited) are driven without a network or
+;;; real delays.
+
+(in-package #:cl-user)
+
+(defpackage #:pure-tls/acme/test
+  (:use #:cl #:fiveam)
+  (:export #:run-acme-retry-tests
+           #:acme-retry-tests))
+
+(in-package #:pure-tls/acme/test)
+
+(def-suite acme-retry-tests
+  :description "Retry/restart handling for recoverable ACME HTTP responses.")
+
+(in-suite acme-retry-tests)
+
+;;;; ---------------------------------------------------------------------------
+;;;; Stub transport
+;;;; ---------------------------------------------------------------------------
+
+(defvar *stub-requests*)   ; list of (:url u :method m :content c), in call order
+(defvar *stub-responses*)  ; queue of (body status headers)
+(defvar *stub-sleeps*)     ; list of requested sleep durations, in order
+
+(defun stub-request (url &rest args &key method content &allow-other-keys)
+  "Stand-in for *http-request-function*: records the call and pops the next
+   queued (body status headers) triple."
+  (declare (ignore args))
+  (setf *stub-requests*
+        (append *stub-requests*
+                (list (list :url url :method method :content content))))
+  (let ((response (pop *stub-responses*)))
+    (unless response
+      (error "stub-request: response queue exhausted for ~A" url))
+    (values (first response) (second response) (third response))))
+
+(defun stub-sleep (seconds)
+  "Stand-in for *sleep-function*: records the duration instead of sleeping."
+  (setf *stub-sleeps* (append *stub-sleeps* (list seconds))))
+
+(defmacro with-acme-stub ((responses) &body body)
+  "Run BODY with the ACME HTTP and sleep seams stubbed. RESPONSES is a list of
+   (body status headers) triples returned in order."
+  `(let ((*stub-requests* nil)
+         (*stub-responses* (copy-list ,responses))
+         (*stub-sleeps* nil)
+         (acme::*http-request-function* #'stub-request)
+         (acme::*sleep-function* #'stub-sleep))
+     ,@body))
+
+(defun make-test-client ()
+  "Build an ACME client wired for stubbed transport: a fresh account key, an
+   account URL, and a directory with the endpoints the tests need. No disk
+   store is touched."
+  (let ((client (acme::%make-acme-client
+                 :directory-url "https://example.test/directory")))
+    (setf (acme::acme-client-account-key client)
+          (ironclad:generate-key-pair :secp256r1))
+    (setf (acme::acme-client-account-url client) "https://example.test/acct/1")
+    (setf (acme::acme-client-directory client)
+          '((:new-nonce . "https://example.test/new-nonce")
+            (:new-account . "https://example.test/new-account")
+            (:new-order . "https://example.test/new-order")))
+    client))
+
+(defun request-nonce (request)
+  "Decode the base64url JWS in REQUEST's :content and return its protected
+   header nonce."
+  (let* ((jws (cl-json:decode-json-from-string (getf request :content)))
+         (protected64 (rest (assoc :protected jws)))
+         (protected-json (flexi-streams:octets-to-string
+                          (acme::base64url-decode protected64)
+                          :external-format :utf-8))
+         (protected (cl-json:decode-json-from-string protected-json)))
+    (rest (assoc :nonce protected))))
+
+;;;; ---------------------------------------------------------------------------
+;;;; Tests
+;;;; ---------------------------------------------------------------------------
+
+(test bad-nonce-refreshes-and-retries
+  "A badNonce response is retried once, re-signed with the fresh nonce the
+   server returned, and the success body is returned."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"type\":\"urn:ietf:params:acme:error:badNonce\",\"detail\":\"bad nonce\"}"
+                400 '((:replay-nonce . "nonce-fresh")))
+          (list "{\"status\":\"valid\"}"
+                200 '((:replay-nonce . "nonce-3")))))
+      (multiple-value-bind (response status)
+          (acme::client-post client "https://example.test/order" nil :use-kid t)
+        (is (= 2 (length *stub-requests*))
+            "badNonce should produce exactly 2 requests (1 retry)")
+        (is (= 200 status))
+        (is (string= "valid" (rest (assoc :status response))))
+        (is (string= "nonce-1" (request-nonce (first *stub-requests*)))
+            "first request signs with the original nonce")
+        (is (string= "nonce-fresh" (request-nonce (second *stub-requests*)))
+            "retry must be re-signed with the fresh nonce from the badNonce response")))))
+
+(test download-retries-not-ready-until-pem
+  "A 202/not-ready download waits per Retry-After, retries, and returns the PEM
+   chain (the real-world 'cert issued but download returned no PEM' fix)."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "" 202 '((:retry-after . "1") (:replay-nonce . "nonce-2")))
+          (list (format nil "-----BEGIN CERTIFICATE-----~%MIIBfake~%-----END CERTIFICATE-----~%")
+                200 '((:replay-nonce . "nonce-3")))))
+      (let ((pem (acme:client-download-certificate client "https://example.test/cert")))
+        (is (= 2 (length *stub-requests*))
+            "download should retry the not-ready response once (2 requests)")
+        (is (not (null pem))
+            "download must return the PEM after the bounded 202 wait, not NIL")
+        (is (and (stringp pem) (search "BEGIN CERTIFICATE" pem))
+            "returned body must be the PEM certificate chain")
+        (is (equal '(1) *stub-sleeps*)
+            "should wait exactly once, per Retry-After, via the sleep seam")))))
+
+(test bad-nonce-on-download-returns-raw-pem
+  "The real 'cert issued but download returned no PEM' failure: the download
+   POST-as-GET is rejected with HTTP 400 badNonce. The download must refresh the
+   nonce, retry, and return the RAW PEM body on 200 -- never NIL, and never a
+   JSON-decoded alist (the 200 success body is raw PEM, only the 400 error body
+   is JSON)."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"type\":\"urn:ietf:params:acme:error:badNonce\",\"status\":400}"
+                400 '((:replay-nonce . "nonce-download-fresh")))
+          (list (format nil "-----BEGIN CERTIFICATE-----~%MIIBfake~%-----END CERTIFICATE-----~%")
+                200 nil)))
+      (let ((pem (acme:client-download-certificate client "https://example.test/cert")))
+        (is (= 2 (length *stub-requests*))
+            "badNonce on download must retry once (2 requests)")
+        (is (string= "nonce-download-fresh"
+                     (request-nonce (second *stub-requests*)))
+            "the retry must be re-signed with the fresh nonce from the 400 badNonce")
+        (is (not (null pem))
+            "download must return the PEM after the badNonce retry, not NIL")
+        (is (stringp pem)
+            "the 200 body is raw PEM: it must be returned as a string, never JSON-decoded")
+        (is (search "BEGIN CERTIFICATE" pem)
+            "returned body must be the raw PEM certificate chain")))))
+
+(test rate-limited-waits-and-retries
+  "A 429/rateLimited response waits per Retry-After, retries, and succeeds."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"type\":\"urn:ietf:params:acme:error:rateLimited\",\"detail\":\"slow down\"}"
+                429 '((:retry-after . "2") (:replay-nonce . "nonce-2")))
+          (list "{\"status\":\"ready\"}"
+                200 '((:replay-nonce . "nonce-3")))))
+      (multiple-value-bind (response status)
+          (acme::client-post client "https://example.test/order" nil :use-kid t)
+        (is (= 2 (length *stub-requests*))
+            "rate limit should be retried once (2 requests)")
+        (is (= 200 status))
+        (is (string= "ready" (rest (assoc :status response))))
+        (is (equal '(2) *stub-sleeps*)
+            "should wait per Retry-After via the sleep seam")))))
+
+(test persistent-bad-nonce-is-bounded
+  "A server that always returns badNonce is retried up to 3 times, then the
+   condition surfaces cleanly (no infinite loop, no crash). Under an
+   established handler the acme-bad-nonce condition propagates; with no handler
+   at all SIGNAL simply returns and the 400 response is surfaced to the caller
+   as before v1.12.0. Either way recovery is bounded to 4 total requests."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((loop repeat 8
+               collect (list "{\"type\":\"urn:ietf:params:acme:error:badNonce\",\"detail\":\"bad nonce\"}"
+                             400 '((:replay-nonce . "nonce-x")))))
+      (signals acme:acme-bad-nonce
+        (acme::client-post client "https://example.test/order" nil :use-kid t))
+      (is (= 4 (length *stub-requests*))
+          "badNonce retries are bounded to 3 (4 total requests)"))))
+
+(test poll-status-tolerates-numeric-status
+  "A poll response whose :status is numeric (a problem document's status) is
+   treated as non-terminal rather than compared as a string; polling recovers
+   to :valid on a later response."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"status\":202}" 200 '((:replay-nonce . "nonce-2")))
+          (list "{\"status\":\"valid\"}" 200 '((:replay-nonce . "nonce-3")))))
+      (multiple-value-bind (response state)
+          (acme:client-poll-status client "https://example.test/order"
+                                    :max-attempts 5 :delay 1)
+        (is (eq :valid state)
+            "a numeric :status must not crash; poll recovers to :valid")
+        (is (string= "valid" (rest (assoc :status response))))
+        (is (= 2 (length *stub-requests*)))
+        (is (equal '(1) *stub-sleeps*)
+            "poll waits its own single interval between attempts, never nesting")))))
+
+(test terminal-error-is-not-retried
+  "A non-recoverable 4xx is not retried; the caller raises as before v1.12.0."
+  (let ((client (make-test-client)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"type\":\"urn:ietf:params:acme:error:malformed\",\"detail\":\"bad request\"}"
+                400 '((:replay-nonce . "nonce-2")))
+          (list "{\"status\":\"valid\"}" 200 nil)))
+      (signals acme:acme-order-error
+        (acme:client-new-order client "example.test"))
+      (is (= 1 (length *stub-requests*))
+          "a non-recoverable 4xx must not be retried"))))
+
+;;;; ---------------------------------------------------------------------------
+;;;; Runner
+;;;; ---------------------------------------------------------------------------
+
+(defun run-acme-retry-tests ()
+  "Run the ACME client retry test suite. Returns T if all tests pass."
+  (format t "~&=== Running ACME Client Retry Tests ===~%~%")
+  (run! 'acme-retry-tests))


### PR DESCRIPTION
### Problem
Certificate issuance against a real CA fails intermittently under load. The ACME
client retried a stale-nonce rejection (RFC 8555 §6.5 `badNonce`) on its main
signed-POST path, but `client-download-certificate` issued its POST-as-GET
directly, outside that path — so a `badNonce` on the certificate download
collapsed an already-issued certificate to a failed fetch (`(if (= status 200)
body-str nil)` returned `nil`). Rate-limited (`429`/`rateLimited`) and not-ready
(`202`) responses were not handled anywhere.

Because the download bypass is nonce-rate-driven, a CA that injects `badNonce` on
a fraction of requests (as Let's Encrypt and Pebble do) drops a proportional
fraction of otherwise-successful issuances at the very last step.

### Approach
Route every ACME request through a single recovery layer built on the condition
system. A recoverable response signals a typed condition; a bounded handler maps
it onto a `retry` restart that re-drives the offending request **without
unwinding the stack** — refreshing the nonce for `badNonce`, or waiting per
`Retry-After` for `429`/`202`. The certificate download now shares this path,
which closes the gap that dropped issued certs.

New conditions (subclasses of the existing `acme-error`):
`acme-http-error` → `acme-bad-nonce`, `acme-not-ready`, `acme-rate-limited`.
A `with-acme-retries` macro establishes the policy; each public client function
wraps itself with sensible defaults, and the macro is exported so a caller can
place one policy around a whole issuance.

### Behavior / compatibility
- Public function return values are unchanged for success and for terminal
  (non-recoverable) responses. Callers that check status and raise still do so.
- `client-download-certificate` returns the raw certificate chain on `200`
  (no JSON decode on the success path) and now retries a recoverable failure
  first; it returns `nil` only on a genuine terminal failure or exhausted budget.
- `client-poll-status` remains a single loop (it is the order-readiness primitive
  a driver calls); it now tolerates a non-string `status` and uses `Retry-After`
  for its own sleep interval. No nested readiness loop is introduced.
- `client-finalize-order` returns a `202` as-is; order readiness stays the
  caller's poll, not a second client-side wait.
- Recovery is bounded by both a retry count and a total-wait ceiling, and the
  handler declines cleanly when a budget is exhausted — it never loops forever.

### Tests
Adds a `pure-tls/acme/test` system (fiveam) that stubs the HTTP transport via an
internal `*http-request-function*` seam and a no-op sleep seam. 7 tests / 26
checks, all green: nonce refresh-and-retry (re-signed with the fresh nonce),
rate-limit and not-ready waits, the certificate-download `badNonce` path
returning the raw PEM, bounded persistent-`badNonce`, non-recoverable `4xx` not
retried, and `poll-status` tolerance of a numeric status.

### End-to-end validation
Validated against Pebble with server-side `badNonce` injection
(`PEBBLE_WFE_NONCEREJECT`). Injection was cranked to ~40% per request — well
above real-CA rates — to force the failure at the certificate-download step:

- **Before:** ~30% of orders that reached download silently lost an
  already-issued certificate. The download `POST` hit a `badNonce`, and because
  the download path issued its request outside the retried POST path, the `400`
  collapsed to `nil` and the certificate was dropped.
- **After:** zero silent drops across the same run. Downloads that hit a
  `badNonce` refreshed the nonce and completed, with several recovering mid-run
  from a `400` to a `200`; every issued order produced its certificate.

At the 5–10% injection rates real CAs exhibit, the pre-change loss is smaller
but nonzero — the change eliminates the failure mode rather than reducing it.
Any residual exhaustion of the bounded retry budget now surfaces as a signaled
`acme-bad-nonce` condition, never a silent `nil`.

### Notes
- The `badNonce` retry budget defaults to 3 (RFC 8555 §6.5 requires one retry;
  the extra margin covers CAs that inject `badNonce` at a higher rate). It, and
  the `Retry-After` attempt/total-wait ceilings, are keyword parameters of
  `with-acme-retries`, so a caller can tune them for its CA.
- `Retry-After` in integer-seconds form is honored; the HTTP-date form falls back
  to a small default delay (waiting is bounded by the total-wait ceiling
  regardless). Happy to add IMF-fixdate parsing if you'd prefer.
- Production transport is unchanged: `*http-request-function*` defaults to
  `drakma:http-request`; the seam exists only so the retry logic is unit-testable
  without a live CA.
