### PR TITLE
Do not log the account contact address during ACME registration

### DIFF
--- a/acme/acme-client.lisp
+++ b/acme/acme-client.lisp
@@ -355,7 +355,7 @@
 (defun client-register-account (client email)
   "Register new account or fetch existing one.
    Returns the account URL on success."
-  (client-log client :info "Registering account for ~A" email)
+  (client-log client :info "Registering ACME account")
   (multiple-value-bind (response status location)
       (client-post client
                    (rest (assoc :new-account (acme-client-directory client)))

--- a/test/acme/client-retry-tests.lisp
+++ b/test/acme/client-retry-tests.lisp
@@ -226,6 +226,32 @@
       (is (= 1 (length *stub-requests*))
           "a non-recoverable 4xx must not be retried"))))
 
+(test register-account-log-omits-account-email
+  "The pre-POST account-registration log must never carry the account email.
+   Install a capturing logger, drive registration over the stubbed transport
+   (no network), and assert the registration log line is emitted verbatim with
+   no '@' and no address text anywhere in what was logged."
+  (let ((client (make-test-client))
+        (captured '()))
+    (setf (acme::acme-client-logger client)
+          (lambda (level format-string &rest args)
+            (declare (ignore level))
+            (push (apply #'format nil format-string args) captured)))
+    (setf (acme::acme-client-nonce client) "nonce-1")
+    (with-acme-stub
+        ((list
+          (list "{\"status\":\"valid\"}" 201
+                '((:location . "https://example.test/acct/1")
+                  (:replay-nonce . "nonce-2")))))
+      (acme::client-register-account client "ops@example.test"))
+    (let ((messages (reverse captured)))
+      (is (member "Registering ACME account" messages :test #'string=)
+          "the registration log line must be emitted verbatim, address-free")
+      (is (notany (lambda (m) (find #\@ m)) messages)
+          "no emitted log line may contain an @ (the account email must not leak)")
+      (is (notany (lambda (m) (search "ops@example.test" m)) messages)
+          "the account email must never appear in any emitted log line"))))
+
 ;;;; ---------------------------------------------------------------------------
 ;;;; Runner
 ;;;; ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

`client-register-account` logs the account contact address verbatim at `:info` before the registration POST:

```lisp
(client-log client :info "Registering account for ~A" email)
```

That address then reaches every configured log sink. For a server running the ACME path unattended, the contact address is durable personal data landing in logs that are routinely rotated to disk, forwarded to syslog, or shipped to an aggregator — none of which the operator necessarily treats as sensitive storage. The log call sits below any consumer-supplied logger, so the library is the only party that can decide this.

### Approach

Log the registration event without the address.

The address is untouched everywhere the protocol requires it: it still travels in the `contact` field of the registration POST body in `mailto:` form (RFC 8555 §7.3), which is the only place the CA needs it.

### Behavior / compatibility

- No API change. `client-register-account`'s signature, return value, and error behavior are identical.
- The only observable difference is the text of one `:info` log line.
- This is the sole logging site for the address in the ACME sources; the remaining occurrences are the POST body above, the `acme-acceptor` slot that carries it, and `make-acme-acceptor`'s parameter — none of which log.

### Tests

Adds `register-account-log-omits-account-email` to the existing ACME retry suite. It installs a capturing logger, drives a registration over the stubbed transport (no network), and asserts that the registration line is emitted verbatim and that no emitted line contains either an `@` or the address text.

Verified on this branch against the ACME suite: 29 checks, all passing. As a control, reverting the one-line change makes exactly the three new checks fail and leaves the other tests green.

### Reviewer note

The `@`-absence assertion is deliberately broad — it covers every line logged during registration, not just the changed one — so that a future log statement on this path cannot silently reintroduce the leak. If you would rather it assert only against the single registration line, that is a one-line change.