### PR TITLE
Harden handshake reassembly against oversized fragmented messages

### DIFF
--- a/src/constants.lisp
+++ b/src/constants.lisp
@@ -251,6 +251,18 @@
    0 means no limit. Set to a positive value to enforce a limit.
    Used to prevent DoS via excessively large certificate chains.")
 
+(defconstant +max-handshake-message-length+ (1- (expt 2 24))
+  "Protocol maximum for a handshake message body: the uint24 length field
+   in the handshake header cannot encode more than 2^24 - 1 bytes.")
+
+(defparameter *max-handshake-message-size* +max-record-size+
+  "Maximum body size in bytes accepted for a non-certificate handshake
+   message. Enforced as soon as the peer's advertised uint24 length is
+   visible, before buffering further record fragments, to prevent DoS via
+   huge fragmented handshake messages. Certificate messages are instead
+   bounded by *MAX-CERTIFICATE-LIST-SIZE* (or the uint24 protocol maximum
+   when that is 0/unlimited).")
+
 ;;;; HPKE Constants (RFC 9180)
 
 ;; HPKE Modes

--- a/src/handshake/client.lisp
+++ b/src/handshake/client.lisp
@@ -40,7 +40,9 @@
   ;; Handshake transcript (raw bytes for hashing)
   (transcript nil :type (or null octet-vector))
   ;; Buffer for handshake messages (multiple messages may arrive in one record)
-  (message-buffer nil :type (or null octet-vector))
+  ;; Reassembly buffer: a simple octet vector or an adjustable vector with
+  ;; fill pointer (see handshake-buffer-append), hence (vector octet).
+  (message-buffer nil :type (or null (vector octet)))
   ;; Server's certificate (parsed X.509)
   (peer-certificate nil)
   ;; Full certificate chain (list of parsed certificates)
@@ -1823,7 +1825,10 @@
   ;; Read more data if needed
   (loop while (not (handshake-buffer-has-complete-message-p
                     (client-handshake-message-buffer hs)))
-        do (handler-case
+        ;; Reject an over-large advertised message before buffering more
+        do (check-handshake-buffer-size (client-handshake-message-buffer hs)
+                                        (client-handshake-record-layer hs))
+           (handler-case
                (multiple-value-bind (content-type data)
                    (record-layer-read (client-handshake-record-layer hs))
                  ;; Handle alerts
@@ -1837,9 +1842,7 @@
                             :message (format nil ":UNEXPECTED_MESSAGE: Expected handshake, got content type ~D" content-type)))
                    ;; Append to buffer
                    (setf (client-handshake-message-buffer hs)
-                         (if (client-handshake-message-buffer hs)
-                             (concat-octet-vectors (client-handshake-message-buffer hs) data)
-                             data))))
+                         (handshake-buffer-append (client-handshake-message-buffer hs) data))))
              ;; Handle record overflow - send alert and re-signal
              (tls-record-overflow (e)
                (handler-case
@@ -2088,7 +2091,10 @@
   ;; Read more data if needed until we have a complete message
   (loop while (not (handshake-buffer-has-complete-message-p
                     (client-handshake-message-buffer hs)))
-        do (handler-case
+        ;; Reject an over-large advertised message before buffering more
+        do (check-handshake-buffer-size (client-handshake-message-buffer hs)
+                                        (client-handshake-record-layer hs))
+           (handler-case
                (multiple-value-bind (content-type data)
                    (record-layer-read (client-handshake-record-layer hs))
                  ;; Handle alerts
@@ -2102,9 +2108,7 @@
                             :message (format nil ":UNEXPECTED_MESSAGE: Expected handshake, got content type ~D" content-type)))
                    ;; Append to buffer
                    (setf (client-handshake-message-buffer hs)
-                         (if (client-handshake-message-buffer hs)
-                             (concat-octet-vectors (client-handshake-message-buffer hs) data)
-                             data))))
+                         (handshake-buffer-append (client-handshake-message-buffer hs) data))))
              ;; Handle record overflow - send alert and re-signal
              (tls-record-overflow (e)
                (handler-case

--- a/src/handshake/messages.lisp
+++ b/src/handshake/messages.lisp
@@ -470,6 +470,70 @@
     (let ((msg-length (decode-uint24 buffer 1)))
       (>= (length buffer) (+ 4 msg-length)))))
 
+(defun max-handshake-message-body-size (msg-type)
+  "Return the maximum acceptable body size in bytes for a handshake message
+   of MSG-TYPE. Certificate messages may carry a peer certificate chain and
+   are bounded by *MAX-CERTIFICATE-LIST-SIZE* (plus framing overhead for the
+   certificate_request_context and list length), or by the uint24 protocol
+   maximum when that is 0/unlimited. All other messages are bounded by
+   *MAX-HANDSHAKE-MESSAGE-SIZE*."
+  (if (= msg-type +handshake-certificate+)
+      (if (plusp *max-certificate-list-size*)
+          ;; context length (1) + context (<= 255) + list length (3)
+          (+ *max-certificate-list-size* 259)
+          +max-handshake-message-length+)
+      *max-handshake-message-size*))
+
+(defun check-handshake-buffer-size (buffer record-layer &key max-body-size)
+  "Reject an over-large handshake message before buffering more fragments.
+   Once BUFFER holds the 4-byte handshake header, compare the advertised
+   uint24 body length against MAX-BODY-SIZE (default: the per-message-type
+   limit from MAX-HANDSHAKE-MESSAGE-BODY-SIZE). On violation, send a fatal
+   illegal_parameter alert on RECORD-LAYER (when non-NIL) and signal
+   TLS-HANDSHAKE-ERROR. No-op while the header is still incomplete."
+  (when (and buffer (>= (length buffer) 4))
+    (let* ((msg-type (aref buffer 0))
+           (msg-length (decode-uint24 buffer 1))
+           (max-body (or max-body-size (max-handshake-message-body-size msg-type))))
+      (when (> msg-length max-body)
+        (when record-layer
+          (ignore-errors
+            (record-layer-write-alert record-layer
+                                      +alert-level-fatal+
+                                      +alert-illegal-parameter+)))
+        (error 'tls-handshake-error
+               :message (format nil ":EXCESSIVE_MESSAGE_SIZE: ~A handshake message length ~D exceeds maximum ~D"
+                                (handshake-message-name msg-type)
+                                msg-length max-body))))))
+
+(defun handshake-buffer-append (buffer data)
+  "Append octet vector DATA to the handshake reassembly BUFFER (which may be
+   NIL) and return the resulting buffer. The result is an adjustable octet
+   vector with a fill pointer, grown geometrically, so reassembling a message
+   from many record fragments copies each fragment O(1) times instead of
+   re-copying the whole accumulated buffer per fragment."
+  (let ((data-len (length data)))
+    (if (and buffer
+             (adjustable-array-p buffer)
+             (array-has-fill-pointer-p buffer))
+        (let* ((old-len (fill-pointer buffer))
+               (needed (+ old-len data-len)))
+          (when (> needed (array-dimension buffer 0))
+            (adjust-array buffer (max needed (* 2 (array-dimension buffer 0)))))
+          (setf (fill-pointer buffer) needed)
+          (replace buffer data :start1 old-len)
+          buffer)
+        (let* ((old-len (if buffer (length buffer) 0))
+               (needed (+ old-len data-len))
+               (new (make-array (max needed 64)
+                                :element-type 'octet
+                                :adjustable t
+                                :fill-pointer needed)))
+          (when buffer
+            (replace new buffer))
+          (replace new data :start1 old-len)
+          new))))
+
 (defun handshake-buffer-extract-message (buffer)
   "Extract one complete handshake message from the buffer.
    Returns (VALUES message-bytes remaining-buffer).

--- a/src/handshake/server.lisp
+++ b/src/handshake/server.lisp
@@ -70,7 +70,9 @@
   (resumption-master-secret nil :type (or null octet-vector))  ; For ticket generation
   (ticket-nonce-counter 0 :type fixnum)  ; Counter for ticket nonces
   ;; Message buffer for reassembling fragmented handshake messages
-  (message-buffer nil :type (or null octet-vector))
+  ;; Reassembly buffer: a simple octet vector or an adjustable vector with
+  ;; fill pointer (see handshake-buffer-append), hence (vector octet).
+  (message-buffer nil :type (or null (vector octet)))
   ;; HelloRetryRequest state
   (hello-retry-sent nil :type boolean)  ; T if we've sent HRR
   (hrr-selected-group nil)              ; Group we requested in HRR
@@ -942,7 +944,10 @@
   ;; Read more data if needed until we have a complete message
   (loop while (not (handshake-buffer-has-complete-message-p
                     (server-handshake-message-buffer hs)))
-        do (handler-case
+        ;; Reject an over-large advertised message before buffering more
+        do (check-handshake-buffer-size (server-handshake-message-buffer hs)
+                                        (server-handshake-record-layer hs))
+           (handler-case
                (multiple-value-bind (content-type data)
                    (record-layer-read (server-handshake-record-layer hs))
                  ;; Handle alerts
@@ -957,9 +962,7 @@
                             :state (server-handshake-state hs)))
                    ;; Append to buffer
                    (setf (server-handshake-message-buffer hs)
-                         (if (server-handshake-message-buffer hs)
-                             (concat-octet-vectors (server-handshake-message-buffer hs) data)
-                             data))))
+                         (handshake-buffer-append (server-handshake-message-buffer hs) data))))
              ;; Handle record overflow - send alert and re-signal
              (tls-record-overflow (e)
                (handler-case

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -111,6 +111,7 @@
    #:*default-buffer-size*
    #:*default-verify-mode*
    #:*max-certificate-list-size*
+   #:*max-handshake-message-size*
 
    ;; Session resumption
    #:*session-ticket-cache*

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -271,11 +271,17 @@
              (error 'tls-decode-error
                     :message ":DECODE_ERROR: Zero-length handshake record"))
            ;; Append incoming data to the reassembly buffer
-           (let ((buf (tls-stream-handshake-message-buffer stream)))
-             (setf (tls-stream-handshake-message-buffer stream)
-                   (if buf
-                       (concatenate '(vector (unsigned-byte 8)) buf data)
-                       data)))
+           (setf (tls-stream-handshake-message-buffer stream)
+                 (handshake-buffer-append
+                  (tls-stream-handshake-message-buffer stream) data))
+           ;; Post-handshake messages (KeyUpdate, NewSessionTicket) are small;
+           ;; reject over-large advertised lengths before buffering more.
+           ;; Certificate messages are never legitimate here, so the plain
+           ;; cap applies to all message types.
+           (check-handshake-buffer-size
+            (tls-stream-handshake-message-buffer stream)
+            (tls-stream-record-layer stream)
+            :max-body-size *max-handshake-message-size*)
            ;; Process all complete handshake messages in the buffer
            (loop while (handshake-buffer-has-complete-message-p
                         (tls-stream-handshake-message-buffer stream))

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -709,6 +709,100 @@
   (is (not (pure-tls::hostname-matches-p "*.com" "foo.com")))
   (is (not (pure-tls::hostname-matches-p "*.co.uk" "foo.co.uk"))))
 
+;;;; ---------------------------------------------------------------------------
+;;;; Handshake reassembly hardening: a peer controls the uint24 length in the
+;;;; handshake message header and could previously force pure-tls to buffer up
+;;;; to 16 MiB per message via many record-sized fragments, with O(n^2) copy
+;;;; work from repeated full-buffer concatenation.  The fix (a) rejects an
+;;;; excessive advertised length as soon as the 4-byte header is visible,
+;;;; before further fragments are buffered, and (b) reassembles into a
+;;;; growable buffer so each fragment is copied O(1) times.
+;;;; ---------------------------------------------------------------------------
+
+(defun %hs-header (msg-type body-length &optional (body-bytes 0))
+  "Build a handshake message prefix: 4-byte header advertising BODY-LENGTH,
+   followed by BODY-BYTES zero bytes of (possibly partial) body."
+  (pure-tls::concat-octet-vectors
+   (pure-tls::octet-vector msg-type
+                           (ldb (byte 8 16) body-length)
+                           (ldb (byte 8 8) body-length)
+                           (ldb (byte 8 0) body-length))
+   (pure-tls::make-octet-vector body-bytes)))
+
+(test handshake-buffer-rejects-excessive-non-certificate-length
+  "A non-certificate handshake header advertising one byte over
+   *max-handshake-message-size* is rejected before any further append."
+  (let ((buffer (%hs-header pure-tls::+handshake-finished+
+                            (1+ pure-tls::*max-handshake-message-size*))))
+    (signals pure-tls:tls-handshake-error
+      (pure-tls::check-handshake-buffer-size buffer nil))))
+
+(test handshake-buffer-accepts-length-at-cap
+  "A handshake header advertising exactly the configured maximum passes the
+   size check (and an incomplete header is never checked)."
+  (is-false (pure-tls::check-handshake-buffer-size
+             (%hs-header pure-tls::+handshake-finished+
+                         pure-tls::*max-handshake-message-size*)
+             nil))
+  ;; Header incomplete: no length to validate yet
+  (is-false (pure-tls::check-handshake-buffer-size
+             (pure-tls::octet-vector pure-tls::+handshake-finished+ 0) nil)))
+
+(test handshake-buffer-certificate-honors-configured-cap
+  "A Certificate message is bounded by *max-certificate-list-size* (plus
+   framing overhead) when that limit is set, and rejected above it."
+  (let ((pure-tls:*max-certificate-list-size* 1000))
+    ;; Within cap + framing overhead: accepted
+    (is-false (pure-tls::check-handshake-buffer-size
+               (%hs-header pure-tls::+handshake-certificate+ 1259) nil))
+    ;; One byte over: rejected
+    (signals pure-tls:tls-handshake-error
+      (pure-tls::check-handshake-buffer-size
+       (%hs-header pure-tls::+handshake-certificate+ 1260) nil))))
+
+(test handshake-buffer-certificate-unlimited-allows-protocol-max
+  "With *max-certificate-list-size* = 0 (unlimited), a Certificate message may
+   advertise up to the uint24 protocol maximum, preserving existing behavior."
+  (let ((pure-tls:*max-certificate-list-size* 0))
+    (is-false (pure-tls::check-handshake-buffer-size
+               (%hs-header pure-tls::+handshake-certificate+ #xFFFFFF) nil))
+    ;; But a non-certificate type claiming the same length is still rejected
+    (signals pure-tls:tls-handshake-error
+      (pure-tls::check-handshake-buffer-size
+       (%hs-header pure-tls::+handshake-encrypted-extensions+ #xFFFFFF) nil))))
+
+(test handshake-buffer-fragmented-message-reassembles
+  "A message fragmented across several appends still reassembles and extracts
+   correctly through the growable reassembly buffer."
+  (let* ((body-length 100)
+         (fragment-1 (%hs-header pure-tls::+handshake-finished+ body-length 40))
+         (fragment-2 (pure-tls::make-octet-vector 40 :initial-element 1))
+         (fragment-3 (pure-tls::make-octet-vector 20 :initial-element 2))
+         (buffer nil))
+    (setf buffer (pure-tls::handshake-buffer-append buffer fragment-1))
+    (is-false (pure-tls::handshake-buffer-has-complete-message-p buffer))
+    (is-false (pure-tls::check-handshake-buffer-size buffer nil))
+    (setf buffer (pure-tls::handshake-buffer-append buffer fragment-2))
+    (is-false (pure-tls::handshake-buffer-has-complete-message-p buffer))
+    (setf buffer (pure-tls::handshake-buffer-append buffer fragment-3))
+    (is-true (pure-tls::handshake-buffer-has-complete-message-p buffer))
+    (multiple-value-bind (message-bytes remaining)
+        (pure-tls::handshake-buffer-extract-message buffer)
+      (is (null remaining))
+      (is (equalp (pure-tls::concat-octet-vectors fragment-1 fragment-2 fragment-3)
+                  message-bytes)))))
+
+(test handshake-buffer-append-grows-in-place
+  "handshake-buffer-append reuses the growable buffer across appends instead
+   of allocating and re-copying the full accumulated buffer per fragment."
+  (let* ((first (pure-tls::make-octet-vector 512 :initial-element 3))
+         (second (pure-tls::make-octet-vector 512 :initial-element 4))
+         (buffer (pure-tls::handshake-buffer-append nil first)))
+    (is (eq buffer (pure-tls::handshake-buffer-append buffer second)))
+    (is (= 1024 (length buffer)))
+    (is (equalp (pure-tls::concat-octet-vectors first second)
+                (coerce buffer '(vector (unsigned-byte 8)))))))
+
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."
   (format t "~&=== Running pure-tls Security Regression Tests ===~%~%")


### PR DESCRIPTION
A peer controls the uint24 length in the handshake message header and could force pure-tls to buffer up to 16 MiB per message via many record-sized fragments, with O(n²) copy work from repeated full-buffer concatenation (~8 GiB of aggregate copying for one maximal message).

Following BoringSSL's `tls_can_accept_handshake_data` pattern:

- **Reject an excessive advertised length as soon as the 4-byte header is visible**, before buffering further record fragments, sending a fatal `illegal_parameter` alert. Non-certificate messages are capped by the new exported `*max-handshake-message-size*` (default 16384); Certificate messages honor `*max-certificate-list-size*` plus framing overhead, or the uint24 protocol maximum when that is 0/unlimited.
- **Reassemble into an adjustable vector with a fill pointer**, grown geometrically, so each fragment is copied O(1) times instead of re-copying the accumulated buffer per fragment.
- **Enforce the plain (non-certificate) cap for all message types on the post-handshake path** in `streams.lisp`, where a Certificate message is never legitimate.

Adds regression tests covering the cap boundaries, the certificate exception, fragmented reassembly, and in-place buffer growth.

## Testing

- `make unit-tests`: all FiveAM suites 100% pass, including the new `security-regression-tests` cases.
- BoringSSL interop runner: no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
