### PR TITLE
Reject a non-time NOW in verify-certificate-chain

### DIFF
--- a/src/x509/verify.lisp
+++ b/src/x509/verify.lisp
@@ -330,6 +330,27 @@ a full list lives at https://publicsuffix.org/.")
    no EKU extension is treated as unrestricted (RFC 5280 s4.2.1.12).
    CRL fetch timeout is computed from cl-cancel:*current-cancel-context* if set."
   (declare (ignorable hostname check-revocation trust-anchor-mode))  ; Only used conditionally
+
+  ;; NOW and HOSTNAME are optional positional parameters ahead of the keywords, so
+  ;; a caller that goes straight to a keyword argument has it consumed as NOW:
+  ;; (verify-certificate-chain chain roots :check-revocation t) binds NOW to
+  ;; :CHECK-REVOCATION and HOSTNAME to T, and the requested check never runs.
+  ;; What the caller sees after that depends on the platform and on the swallowed
+  ;; value, and none of it names the certificate or the argument responsible.
+  ;; Rejecting the time here, ahead of the native dispatches, gives one condition
+  ;; that says what is wrong, and refuses the variant whose swallowed value is NIL
+  ;; that the native paths would otherwise verify cleanly with no sign an argument
+  ;; went astray.
+  (unless (realp now)
+    (error 'tls-certificate-error
+           :message (format nil
+                            (concatenate 'string
+                                         "Verification time must be a universal time, not ~S; "
+                                         "NOW and HOSTNAME are positional parameters and a "
+                                         "keyword argument passed in their place is silently "
+                                         "consumed.")
+                            now)))
+
   (when (null chain)
     (error 'tls-certificate-error :message "Empty certificate chain"))
 

--- a/src/x509/verify.lisp
+++ b/src/x509/verify.lisp
@@ -351,6 +351,19 @@ a full list lives at https://publicsuffix.org/.")
                                          "consumed.")
                             now)))
 
+  ;; A keyword argument can also land one position further along, on HOSTNAME:
+  ;; (verify-certificate-chain chain roots now :check-revocation) passes the
+  ;; guard above with a genuine time, binds HOSTNAME to :CHECK-REVOCATION, and
+  ;; leaves CHECK-REVOCATION NIL.  HOSTNAME is read only by the Windows and
+  ;; macOS native dispatches, so on the pure-Lisp path nothing ever looks at the
+  ;; swallowed keyword and the call succeeds: the chain verifies to T while the
+  ;; revocation checking the caller asked for was never performed.  A silent
+  ;; success is the worst of the outcomes available here, and rejecting a
+  ;; HOSTNAME that is neither NIL nor a string is what closes it.
+  (unless (or (null hostname) (stringp hostname))
+    (error 'tls-certificate-error
+           :message (format nil "HOSTNAME must be a string or NIL, not ~S; NOW and HOSTNAME are positional parameters ahead of the keywords, so a keyword argument passed in their place is silently consumed and the keyword it names never takes effect." hostname)))
+
   (when (null chain)
     (error 'tls-certificate-error :message "Empty certificate chain"))
 

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -849,6 +849,45 @@
           (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
                                               :check-revocation t))))))
 
+;;;; ---------------------------------------------------------------------------
+;;;; Finding: the same misplacement one position further along is worse, because
+;;;; it succeeds.  With a real time supplied for NOW,
+;;;;   (verify-certificate-chain chain roots now :check-revocation)
+;;;; binds HOSTNAME to :CHECK-REVOCATION and leaves CHECK-REVOCATION NIL.
+;;;; HOSTNAME is read only inside the Windows and macOS native dispatches, so on
+;;;; the pure-Lisp path the swallowed keyword is never looked at: the chain
+;;;; verifies to T and the revocation checking the caller asked for never runs.
+;;;; Nothing in the return value distinguishes that from a chain that really was
+;;;; checked for revocation.
+;;;;
+;;;; Secure behaviour: a HOSTNAME that is neither NIL nor a string is rejected
+;;;; alongside the time, so the misplaced argument fails loudly instead of
+;;;; producing a verification the caller will trust for more than it did.
+;;;; ---------------------------------------------------------------------------
+
+(test keyword-in-hostname-position-is-rejected
+  "A keyword argument landing on the positional HOSTNAME must be rejected, and a
+   correctly positioned call must be unaffected."
+  (let ((pure-tls:*use-windows-certificate-store* nil)
+        (pure-tls:*use-macos-keychain* nil)
+        (now (get-universal-time)))
+    (destructuring-bind (leaf inter)
+        (%pem-chain (test-cert-path "openssl/goodcn2-chain.pem"))
+      (let ((root (pure-tls:parse-certificate-from-file
+                   (test-cert-path "openssl/root-cert.pem"))))
+        ;; Baseline: with all four positionals supplied the chain verifies, so
+        ;; the rejection below is attributable solely to argument position.
+        (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
+                                                now nil :trust-anchor-mode :replace)
+            "Untampered goodcn2 chain should verify")
+        ;; NOW is a genuine time here, so the time guard passes and the keyword
+        ;; lands on HOSTNAME instead.  The pure-Lisp path never reads HOSTNAME,
+        ;; so without a guard this call returns T with revocation checking
+        ;; silently skipped.
+        (signals pure-tls:tls-certificate-error
+          (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
+                                              now :check-revocation))))))
+
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."
   (format t "~&=== Running pure-tls Security Regression Tests ===~%~%")

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -803,6 +803,52 @@
     (is (equalp (pure-tls::concat-octet-vectors first second)
                 (coerce buffer '(vector (unsigned-byte 8)))))))
 
+;;;; ---------------------------------------------------------------------------
+;;;; Finding: a keyword argument passed in place of the positional NOW is
+;;;; swallowed, the check the caller asked for never runs, and the resulting
+;;;; failure names neither the certificate nor the argument responsible.
+;;;;
+;;;; verify-certificate-chain takes NOW and HOSTNAME as positional &optional
+;;;; parameters ahead of its &key parameters, so
+;;;;   (verify-certificate-chain chain roots :check-revocation t)
+;;;; binds NOW to :CHECK-REVOCATION and HOSTNAME to T, leaving CHECK-REVOCATION
+;;;; NIL.  Revocation checking is not applied, and what the caller sees instead
+;;;; depends on the platform.  On Windows and macOS NOW is never read at all,
+;;;; but HOSTNAME is not inert there: both treat a non-NIL hostname as a string
+;;;; and hand it to a foreign string conversion (windows-verify.lisp
+;;;; cffi:with-foreign-string, macos-verify.lisp %cf-string-create, whose
+;;;; argument is declared :string), which rejects a non-string.  On other
+;;;; platforms NOW reaches the pure-Lisp validity checks and raises a bare
+;;;; TYPE-ERROR, not a TLS condition.
+;;;;
+;;;; Secure behaviour: a NOW that is not a universal time is rejected outright,
+;;;; ahead of the native dispatches, so the call fails in one place with an
+;;;; error that says what is wrong rather than failing differently per platform
+;;;; with the requested check quietly skipped.
+;;;; ---------------------------------------------------------------------------
+
+(test chain-verification-rejects-keyword-in-place-of-time
+  "A keyword argument landing on the positional NOW must be rejected, and a
+   correctly positioned call must be unaffected."
+  (let ((pure-tls:*use-windows-certificate-store* nil)
+        (pure-tls:*use-macos-keychain* nil)
+        (now (get-universal-time)))
+    (destructuring-bind (leaf inter)
+        (%pem-chain (test-cert-path "openssl/goodcn2-chain.pem"))
+      (let ((root (pure-tls:parse-certificate-from-file
+                   (test-cert-path "openssl/root-cert.pem"))))
+        ;; Baseline: with all four positionals supplied the chain verifies, so
+        ;; the rejection below is attributable solely to argument position.
+        (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
+                                                now nil :trust-anchor-mode :replace)
+            "Untampered goodcn2 chain should verify")
+        ;; The keyword lands on NOW instead.  This must signal a certificate
+        ;; error naming the problem, rather than fail further in with an error
+        ;; about something else and revocation checking quietly disabled.
+        (signals pure-tls:tls-certificate-error
+          (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
+                                              :check-revocation t))))))
+
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."
   (format t "~&=== Running pure-tls Security Regression Tests ===~%~%")


### PR DESCRIPTION
`verify-certificate-chain` takes `now` and `hostname` as positional `&optional` parameters ahead of its `&key` parameters. A caller who skips the optionals and goes straight to a keyword has that keyword consumed as a positional value:

```lisp
(verify-certificate-chain chain roots :check-revocation t)
```

That binds `now` to `:check-revocation` and `hostname` to `t`, leaving `check-revocation` as `nil`. The requested check is not applied, and what happens next depends on the platform.

On Windows and macOS `now` is never read at all, so nothing there objects to the time. But `hostname` is not inert on that path: both treat a non-nil hostname as a string and hand it to a foreign string conversion, which rejects `t`. On other platforms `now` reaches the pure Lisp validity checks and raises a bare `type-error` about a value that is not a `real`. Either way the error names neither the certificate nor the argument that caused it, and the check the caller asked for never ran.

I made the call fail in one place instead, with an error that says what is wrong. Pass a `now` that is not a universal time and you get a `tls-certificate-error` naming the problem, signalled at function entry ahead of both native dispatches, so the diagnosis no longer depends on which platform you are on.

The lambda list is unchanged, so this is compatible with existing callers. Every existing call site in pure-tls either supplies `now` positionally or omits it and takes the default, and none of them trips the new guard.

One behaviour change worth naming. Where the swallowed keyword's value is `nil`, as in `(verify-certificate-chain chain roots :check-revocation nil)`, `hostname` binds to `nil` as well, and on Windows and macOS the native verification would have run and returned `t` with nothing actually lost. That call is refused now. I think that is the right trade, because a caller cannot tell that shape from the harmful one, but it is a change in behaviour and not purely a fix.

`chain-verification-rejects-keyword-in-place-of-time` in the security regression suite covers both directions: a correctly positioned call that still verifies, and the misplaced keyword that now signals. I confirmed the test goes red with the guard removed.

What I could not check: I ran this on Linux, so the Windows and macOS behaviour above is read from the source, not observed. Both native paths hand a non-NIL hostname to a foreign string conversion (`cffi:with-foreign-string` on Windows, `%cf-string-create` on macOS, whose argument is declared `:string`), and neither accepts `t`, but I have run neither. The fix does not depend on that reading, since the guard sits ahead of both dispatches either way, but it is worth confirming if you have either platform to hand.

Happy to prepare a separate change making `now` and `hostname` keyword parameters, if you would rather change the signature instead. That one touches every call site and the README example, which is why I have kept it out of this PR.
