### PR TITLE
Take the verification time and hostname as keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Use with drakma via cl+ssl compatibility layer (drop-in OpenSSL replacement):
 
 ```lisp
 ;; Enable CRL/OCSP checking during verification
-(pure-tls::verify-certificate-chain chain roots now hostname
+(pure-tls::verify-certificate-chain chain roots
+                                    :now now :hostname hostname
                                     :check-revocation t)
 
 ;; Check a single certificate

--- a/src/handshake/client.lisp
+++ b/src/handshake/client.lisp
@@ -1637,7 +1637,8 @@
                                    nil
                                    hostname)))
           (verify-certificate-chain chain trusted-roots
-                                    (get-universal-time) verify-hostname
+                                    :now (get-universal-time)
+                                    :hostname verify-hostname
                                     :purpose :server-auth))))
     (setf (client-handshake-state hs) :wait-finished)))
 

--- a/src/handshake/server.lisp
+++ b/src/handshake/server.lisp
@@ -813,7 +813,7 @@
           (verify-certificate-chain
            (server-handshake-peer-certificate-chain hs)
            (trust-store-certificates trust-store)
-           (get-universal-time) nil
+           :now (get-universal-time)
            :purpose :client-auth)
         (tls-verification-error (e)
           ;; Map verification reason to appropriate alert

--- a/src/streams.lisp
+++ b/src/streams.lisp
@@ -613,7 +613,8 @@
               (let ((trusted-roots (when trust-store
                                      (trust-store-certificates trust-store))))
                 (verify-certificate-chain chain trusted-roots
-                                          (get-universal-time) hostname
+                                          :now (get-universal-time)
+                                          :hostname hostname
                                           :purpose :server-auth)))
             ;; Record the verified identity when this full handshake proved it
             ;; under +verify-required+ (hostname supplied, hostname + chain

--- a/src/x509/verify.lisp
+++ b/src/x509/verify.lisp
@@ -312,17 +312,17 @@ a full list lives at https://publicsuffix.org/.")
 ;;;
 ;;; For now, we provide basic building blocks.
 
-(defun verify-certificate-chain (chain trusted-roots &optional (now (get-universal-time)) hostname
-                                 &key check-revocation (trust-anchor-mode :replace) purpose)
+(defun verify-certificate-chain (chain trusted-roots
+                                 &key (now (get-universal-time)) hostname
+                                      check-revocation (trust-anchor-mode :replace) purpose)
   "Verify a certificate chain against trusted roots.
    CHAIN is a list of certificates, leaf first.
    TRUSTED-ROOTS is a list of trusted CA certificates. When NIL on Windows/macOS,
    native OS verification uses the system trust store.
    HOSTNAME is optional; if provided, enables hostname verification on native platforms.
    NOW must be a universal time (a non-negative real) and HOSTNAME a string or
-   NIL; both are positional parameters ahead of the keywords, and a value of
-   the wrong type in either slot (such as a misplaced keyword argument)
-   signals TLS-CERTIFICATE-ERROR at entry rather than being silently consumed.
+   NIL; a value of the wrong type in either argument signals
+   TLS-CERTIFICATE-ERROR at entry.
    CHECK-REVOCATION if T, checks certificate revocation via CRL/OCSP (default NIL).
    TRUST-ANCHOR-MODE controls how trusted-roots interact with system store:
      :replace (default) - Use ONLY trusted-roots, ignore system store
@@ -335,42 +335,35 @@ a full list lives at https://publicsuffix.org/.")
    CRL fetch timeout is computed from cl-cancel:*current-cancel-context* if set."
   (declare (ignorable hostname check-revocation trust-anchor-mode))  ; Only used conditionally
 
-  ;; NOW and HOSTNAME are optional positional parameters ahead of the keywords, so
-  ;; a caller that goes straight to a keyword argument has it consumed as NOW:
-  ;; (verify-certificate-chain chain roots :check-revocation t) binds NOW to
-  ;; :CHECK-REVOCATION and HOSTNAME to T, and the requested check never runs.
-  ;; What the caller sees after that depends on the platform and on the swallowed
-  ;; value, and none of it names the certificate or the argument responsible.
-  ;; Rejecting the time here, ahead of the native dispatches, gives one condition
-  ;; that says what is wrong, and refuses the variant whose swallowed value is NIL
-  ;; that the native paths would otherwise verify cleanly with no sign an argument
-  ;; went astray.
+  ;; NOW has no type check of its own further in, and both bad shapes reach the
+  ;; notBefore / notAfter comparisons and fail there without naming the
+  ;; argument.  A value that is not a real raises a bare TYPE-ERROR about REAL,
+  ;; naming the comparison.  A negative real is below every notBefore, so it
+  ;; signals TLS-CERTIFICATE-NOT-YET-VALID and accuses the certificate of
+  ;; something the argument caused.  Rejecting both here, ahead of the native
+  ;; dispatches, gives one condition that names the argument instead.
   (unless (and (realp now) (>= now 0))
     (error 'tls-certificate-error
            :message (format nil
                             "Verification time must be a universal time (a ~
-                             non-negative real), not ~S~:[~;; NOW and HOSTNAME ~
-                             are positional parameters and a keyword argument ~
-                             passed in their place is silently consumed~]."
+                             non-negative real), not ~S~:[~;; a keyword here ~
+                             usually means the value was omitted and the next ~
+                             argument name was read in its place~]."
                             now (keywordp now))))
 
-  ;; A keyword argument can also land one position further along, on HOSTNAME:
-  ;; (verify-certificate-chain chain roots now :check-revocation) passes the
-  ;; guard above with a genuine time, binds HOSTNAME to :CHECK-REVOCATION, and
-  ;; leaves CHECK-REVOCATION NIL.  HOSTNAME is read only by the Windows and
-  ;; macOS native dispatches, so on the pure-Lisp path nothing ever looks at the
-  ;; swallowed keyword and the call succeeds: the chain verifies to T while the
-  ;; revocation checking the caller asked for was never performed.  A silent
-  ;; success is the worst of the outcomes available here, and rejecting a
-  ;; HOSTNAME that is neither NIL nor a string is what closes it.
+  ;; HOSTNAME is read only by the Windows and macOS native dispatches, which
+  ;; hand it to a foreign string conversion.  Without this guard a value that is
+  ;; neither NIL nor a string is a CFFI error on those two platforms and is
+  ;; ignored entirely on the pure-Lisp path, where the chain then verifies to T
+  ;; with no hostname checked at all.  Rejecting it here makes every path
+  ;; agree, and turns the silent success into a condition.
   (unless (or (null hostname) (stringp hostname))
     (error 'tls-certificate-error
            :message (format nil
-                            "HOSTNAME must be a string or NIL, not ~S~:[~;; NOW ~
-                             and HOSTNAME are positional parameters ahead of the ~
-                             keywords, so a keyword argument passed in their ~
-                             place is silently consumed and the keyword it names ~
-                             never takes effect~]."
+                            "HOSTNAME must be a string or NIL, not ~S~:[~;; a ~
+                             keyword here usually means the value was omitted ~
+                             and the next argument name was read in its ~
+                             place~]."
                             hostname (keywordp hostname))))
 
   (when (null chain)

--- a/test/security-regression-tests.lisp
+++ b/test/security-regression-tests.lisp
@@ -109,10 +109,9 @@
                   (pure-tls::certificate-critical-extensions leaf))
           "Fixture leaf should carry a critical ExtendedKeyUsage extension")
       ;; With :purpose :server-auth, a clientAuth-only leaf must be rejected.
-      ;; (now and hostname are positional &optional args before the &key.)
       (signals pure-tls:tls-certificate-error
         (pure-tls::verify-certificate-chain (list leaf) (list root)
-                                            (get-universal-time) nil
+                                            :now (get-universal-time)
                                             :purpose :server-auth)))))
 
 ;;;; ---------------------------------------------------------------------------
@@ -497,7 +496,7 @@
                               :basic-constraints :ca-false)))
       (signals pure-tls:tls-certificate-error
         (pure-tls::verify-certificate-chain (list leaf inter) (list inter)
-                                            now nil :trust-anchor-mode :replace)))
+                                            :now now :trust-anchor-mode :replace)))
     ;; Intermediate carries no BasicConstraints extension at all.
     (let ((leaf (%chain-cert "leaf.example" "Intermediate CA"
                              :basic-constraints :absent))
@@ -505,7 +504,7 @@
                               :basic-constraints :absent)))
       (signals pure-tls:tls-certificate-error
         (pure-tls::verify-certificate-chain (list leaf inter) (list inter)
-                                            now nil :trust-anchor-mode :replace)))))
+                                            :now now :trust-anchor-mode :replace)))))
 
 (test chain-rejects-pathlen-violation
   "A CA asserting pathLenConstraint=0 with an intermediate CA below it in the
@@ -520,7 +519,7 @@
         ;; Baseline: the untampered chain verifies, so the rejection below is
         ;; attributable solely to the path-length constraint.
         (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                                now nil :trust-anchor-mode :replace)
+                                                :now now :trust-anchor-mode :replace)
             "Untampered goodcn2 chain should verify")
         ;; Assert pathLenConstraint=0 on the trusted root: it may issue end
         ;; entities but no intermediate CA -- and the chain has exactly one.
@@ -531,7 +530,7 @@
                 (list :ca t :path-length-constraint 0)))
         (signals pure-tls:tls-certificate-error
           (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                              now nil :trust-anchor-mode :replace))))))
+                                              :now now :trust-anchor-mode :replace))))))
 
 (test chain-rejects-tampered-signature
   "A chain that passes name / CA / pathLen / date checks but whose leaf
@@ -545,7 +544,7 @@
                    (test-cert-path "openssl/root-cert.pem"))))
         ;; Baseline: the untampered chain verifies.
         (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                                now nil :trust-anchor-mode :replace)
+                                                :now now :trust-anchor-mode :replace)
             "Untampered goodcn2 chain should verify")
         ;; Flip one byte of the leaf signature.  Every earlier check still
         ;; passes, so a rejection can only come from signature verification.
@@ -554,7 +553,7 @@
           (setf (pure-tls::x509-certificate-signature leaf) sig))
         (signals pure-tls:tls-certificate-error
           (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                              now nil :trust-anchor-mode :replace))))))
+                                              :now now :trust-anchor-mode :replace))))))
 
 (test chain-rejects-expired-leaf
   "A leaf whose notAfter is in the past must be rejected."
@@ -568,7 +567,7 @@
       ;; tls-certificate-expired is internal to pure-tls (double colon).
       (signals pure-tls::tls-certificate-expired
         (pure-tls::verify-certificate-chain (list leaf root) (list root)
-                                            now nil :trust-anchor-mode :replace)))))
+                                            :now now :trust-anchor-mode :replace)))))
 
 (test chain-rejects-not-yet-valid-leaf
   "A leaf whose notBefore is in the future must be rejected."
@@ -582,7 +581,7 @@
       ;; tls-certificate-not-yet-valid is internal to pure-tls (double colon).
       (signals pure-tls::tls-certificate-not-yet-valid
         (pure-tls::verify-certificate-chain (list leaf root) (list root)
-                                            now nil :trust-anchor-mode :replace)))))
+                                            :now now :trust-anchor-mode :replace)))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; Finding: RFC 5280 4.2.1.3 -- an issuer whose KeyUsage extension is present
@@ -611,7 +610,7 @@
                                :key-usage '(:crl-sign))))
       (signals pure-tls:tls-certificate-error
         (pure-tls::verify-certificate-chain (list leaf issuer) (list issuer)
-                                            now nil :trust-anchor-mode :replace)))))
+                                            :now now :trust-anchor-mode :replace)))))
 
 ;;;; ---------------------------------------------------------------------------
 ;;;; DNS name-safety in hostname verification.
@@ -804,32 +803,23 @@
                 (coerce buffer '(vector (unsigned-byte 8)))))))
 
 ;;;; ---------------------------------------------------------------------------
-;;;; Finding: a keyword argument passed in place of the positional NOW is
-;;;; swallowed, the check the caller asked for never runs, and the resulting
-;;;; failure names neither the certificate nor the argument responsible.
+;;;; Finding: a NOW that is not a real is not type-checked where it is used, so
+;;;; the fault gets misattributed to the certificate.
 ;;;;
-;;;; verify-certificate-chain takes NOW and HOSTNAME as positional &optional
-;;;; parameters ahead of its &key parameters, so
-;;;;   (verify-certificate-chain chain roots :check-revocation t)
-;;;; binds NOW to :CHECK-REVOCATION and HOSTNAME to T, leaving CHECK-REVOCATION
-;;;; NIL.  Revocation checking is not applied, and what the caller sees instead
-;;;; depends on the platform.  On Windows and macOS NOW is never read at all,
-;;;; but HOSTNAME is not inert there: both treat a non-NIL hostname as a string
-;;;; and hand it to a foreign string conversion (windows-verify.lisp
-;;;; cffi:with-foreign-string, macos-verify.lisp %cf-string-create, whose
-;;;; argument is declared :string), which rejects a non-string.  On other
-;;;; platforms NOW reaches the pure-Lisp validity checks and raises a bare
-;;;; TYPE-ERROR, not a TLS condition.
+;;;; A non-real NOW flows into the notBefore / notAfter comparisons and fails
+;;;; there, as a bare TYPE-ERROR naming a comparison rather than the argument
+;;;; that was wrong.  A caller reading that condition sees a problem with the
+;;;; chain it passed in.  On Windows and macOS the native dispatches never read
+;;;; NOW at all, so the same bad value produces a different outcome again.
 ;;;;
-;;;; Secure behaviour: a NOW that is not a universal time is rejected outright,
-;;;; ahead of the native dispatches, so the call fails in one place with an
-;;;; error that says what is wrong rather than failing differently per platform
-;;;; with the requested check quietly skipped.
+;;;; Secure behaviour: a NOW that is not a real is rejected outright, ahead of
+;;;; the native dispatches, so the call fails in one place on every platform
+;;;; with a condition that names the argument responsible.
 ;;;; ---------------------------------------------------------------------------
 
-(test chain-verification-rejects-keyword-in-place-of-time
-  "A keyword argument landing on the positional NOW must be rejected, and a
-   correctly positioned call must be unaffected."
+(test non-real-verification-time-is-rejected
+  "A NOW that is not a real must be rejected, and a call supplying a real one
+   must be unaffected."
   (let ((pure-tls:*use-windows-certificate-store* nil)
         (pure-tls:*use-macos-keychain* nil)
         (now (get-universal-time)))
@@ -837,37 +827,78 @@
         (%pem-chain (test-cert-path "openssl/goodcn2-chain.pem"))
       (let ((root (pure-tls:parse-certificate-from-file
                    (test-cert-path "openssl/root-cert.pem"))))
-        ;; Baseline: with all four positionals supplied the chain verifies, so
-        ;; the rejection below is attributable solely to argument position.
+        ;; Baseline: with a real NOW the chain verifies, so the rejection below
+        ;; is attributable solely to the value of NOW.
         (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                                now nil :trust-anchor-mode :replace)
+                                                :now now :trust-anchor-mode :replace)
             "Untampered goodcn2 chain should verify")
-        ;; The keyword lands on NOW instead.  This must signal a certificate
-        ;; error naming the problem, rather than fail further in with an error
-        ;; about something else and revocation checking quietly disabled.
+        ;; A NOW that is not a real must signal a certificate error naming the
+        ;; argument, rather than reaching the date comparisons and failing there
+        ;; with a condition that reads as a fault in the certificate.
         (signals pure-tls:tls-certificate-error
           (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                              :check-revocation t))))))
+                                              :now :not-a-time))))))
 
 ;;;; ---------------------------------------------------------------------------
-;;;; Finding: the same misplacement one position further along is worse, because
-;;;; it succeeds.  With a real time supplied for NOW,
-;;;;   (verify-certificate-chain chain roots now :check-revocation)
-;;;; binds HOSTNAME to :CHECK-REVOCATION and leaves CHECK-REVOCATION NIL.
-;;;; HOSTNAME is read only inside the Windows and macOS native dispatches, so on
-;;;; the pure-Lisp path the swallowed keyword is never looked at: the chain
-;;;; verifies to T and the revocation checking the caller asked for never runs.
-;;;; Nothing in the return value distinguishes that from a chain that really was
-;;;; checked for revocation.
+;;;; Finding: a negative NOW is a real, so it passes a type check and still
+;;;; reaches the date comparisons, where it is misread as a fact about the
+;;;; certificate.
+;;;;
+;;;; A negative universal time is below every notBefore, so the chain is
+;;;; refused with TLS-CERTIFICATE-NOT-YET-VALID.  The caller is told their
+;;;; certificate is not yet valid when the certificate was never at fault, and
+;;;; nothing in that condition points at the argument that caused it.  This is
+;;;; the half a bare REALP check does not cover.
+;;;;
+;;;; Secure behaviour: NOW is required to be non-negative as well as real, so
+;;;; the bad argument is named at entry instead of being reported as a property
+;;;; of the chain.
+;;;; ---------------------------------------------------------------------------
+
+(test negative-verification-time-is-rejected
+  "A negative NOW must be refused as a bad argument, not passed through to the
+   date comparisons where it reads as a fault in the certificate."
+  (let ((pure-tls:*use-windows-certificate-store* nil)
+        (pure-tls:*use-macos-keychain* nil))
+    (destructuring-bind (leaf inter)
+        (%pem-chain (test-cert-path "openssl/goodcn2-chain.pem"))
+      (let* ((root (pure-tls:parse-certificate-from-file
+                    (test-cert-path "openssl/root-cert.pem")))
+             (condition (handler-case
+                            (progn (pure-tls::verify-certificate-chain
+                                    (list leaf inter root) (list root) :now -1)
+                                   nil)
+                          (pure-tls:tls-certificate-error (e) e))))
+        ;; A negative NOW is below every notBefore, so without the non-negative
+        ;; half of the guard it reaches the date comparisons and signals
+        ;; TLS-CERTIFICATE-NOT-YET-VALID, blaming the certificate for a fault in
+        ;; the argument.  Asserting the condition type is what separates the two.
+        (is (typep condition 'pure-tls:tls-certificate-error)
+            "A negative NOW should signal")
+        (is (not (typep condition 'pure-tls::tls-certificate-not-yet-valid))
+            "A negative NOW should name the argument, not the certificate")))))
+
+;;;; ---------------------------------------------------------------------------
+;;;; Finding: a HOSTNAME that is neither a string nor NIL is read by the two
+;;;; native dispatches and ignored on the pure-Lisp path, and it is the path
+;;;; that ignores it where the call succeeds.
+;;;;
+;;;; HOSTNAME is read only inside the Windows and macOS native dispatches, which
+;;;; hand it to a foreign string conversion (windows-verify.lisp
+;;;; cffi:with-foreign-string, macos-verify.lisp %cf-string-create, whose
+;;;; argument is declared :string).  A non-string is a CFFI error there.  On the
+;;;; pure-Lisp path nothing ever looks at it: the chain verifies to T with no
+;;;; hostname checked, and nothing in the return value distinguishes that from a
+;;;; chain whose hostname really was verified.
 ;;;;
 ;;;; Secure behaviour: a HOSTNAME that is neither NIL nor a string is rejected
-;;;; alongside the time, so the misplaced argument fails loudly instead of
-;;;; producing a verification the caller will trust for more than it did.
+;;;; alongside the time, so every path agrees and the silent success becomes a
+;;;; condition.
 ;;;; ---------------------------------------------------------------------------
 
-(test keyword-in-hostname-position-is-rejected
-  "A keyword argument landing on the positional HOSTNAME must be rejected, and a
-   correctly positioned call must be unaffected."
+(test non-string-hostname-is-rejected
+  "A HOSTNAME that is neither a string nor NIL must be rejected, and a call
+   supplying NIL must be unaffected."
   (let ((pure-tls:*use-windows-certificate-store* nil)
         (pure-tls:*use-macos-keychain* nil)
         (now (get-universal-time)))
@@ -875,18 +906,16 @@
         (%pem-chain (test-cert-path "openssl/goodcn2-chain.pem"))
       (let ((root (pure-tls:parse-certificate-from-file
                    (test-cert-path "openssl/root-cert.pem"))))
-        ;; Baseline: with all four positionals supplied the chain verifies, so
-        ;; the rejection below is attributable solely to argument position.
+        ;; Baseline: with HOSTNAME left at its NIL default the chain verifies,
+        ;; so the rejection below is attributable solely to HOSTNAME.
         (is (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                                now nil :trust-anchor-mode :replace)
+                                                :now now :trust-anchor-mode :replace)
             "Untampered goodcn2 chain should verify")
-        ;; NOW is a genuine time here, so the time guard passes and the keyword
-        ;; lands on HOSTNAME instead.  The pure-Lisp path never reads HOSTNAME,
-        ;; so without a guard this call returns T with revocation checking
-        ;; silently skipped.
+        ;; The pure-Lisp path never reads HOSTNAME, so without the guard this
+        ;; call returns T with no hostname checked at all.
         (signals pure-tls:tls-certificate-error
           (pure-tls::verify-certificate-chain (list leaf inter root) (list root)
-                                              now :check-revocation))))))
+                                              :now now :hostname t))))))
 
 (defun run-security-regression-tests ()
   "Run the security regression suite.  Returns T if all tests pass."


### PR DESCRIPTION
When #23 went in I offered to prepare the signature change separately, and
you said it was still welcome, tracked as `pure-tls-cei`. This is that
change.

`verify-certificate-chain` took `now` and `hostname` as positional
`&optional` parameters ahead of its `&key` parameters, so a caller who
skipped the optionals and went straight to a keyword had it consumed as a
positional value:

```lisp
(verify-certificate-chain chain roots :check-revocation t)
```

That bound `now` to `:check-revocation` and `hostname` to `t`, leaving
`check-revocation` as `nil`, and the revocation check that call asked for
never ran. The guards from #23 catch that one argument at a time, after the
fact, which is the most they can do while the slot is still there to land
in.

Both parameters are keyword parameters now. Name a keyword and you get the
parameter you named; no positional slot remains for one to land in, so the
misplacement the guards were written for can no longer be expressed.

You expected these guards to become removable scaffolding once this landed.
That is right for the reason they were written, and I have kept them anyway,
because each turned out to have a second reason that has nothing to do with
argument position.

Neither bad shape of `now` is caught where `now` is used, and neither
failure names the argument. One that is not a real reaches the notBefore and
notAfter comparisons and raises a bare `type-error` about `real`, which
names the comparison. A negative one is worse, because it does not fail as a
type at all: it is below every notBefore, so the chain is refused with
`tls-certificate-not-yet-valid`, and the caller is told the certificate is
not yet valid when the certificate was never the problem. That is the
misattribution your non-negative tightening was aimed at, and it is the case
for keeping this guard rather than retiring it with the positional slots:
the slots are what let a keyword arrive in `now`, but nothing about removing
them stops a caller computing a bad time, and when one does, nothing else
names the argument.

A `hostname` that is neither a string nor `nil` is read only by the native
dispatches, so without the check it is a foreign string error on Windows and
macOS and is ignored on the pure Lisp path, where the chain then verifies
with no hostname checked at all. Removing that guard restores a silent
success on the path where nothing reads the value.

If you would rather they go, removing them is a clean follow-up and I am
happy to prepare it. I did not want to make that call inside a signature
change, and the tightening you gave them is worth keeping either way.

One edit lands on your text, and I would rather put it in front of you than
leave it to be found in the diff. Both guard messages and the docstring said
that `now` and `hostname` are positional parameters ahead of the keywords
and that a keyword passed in their place is silently consumed. That stops
being true here, so it could not ship as written.

I changed the claim and left your form alone. The literal control string
with tilde-newline continuations stays, and so does the `~:[~;...~]`
conditional on `(keywordp ...)`, because a keyword can still reach either
parameter: not by being consumed from the position in front of it, but when
the value is omitted and the next argument name is read in its place.

```lisp
(verify-certificate-chain chain roots :now :check-revocation)
```

So the clause still bears out logically, and says nothing to a caller
whose own expression produced `nil`:

```
Verification time must be a universal time (a non-negative real), not "x".

Verification time must be a universal time (a non-negative real), not
:CHECK-REVOCATION; a keyword here usually means the value was omitted and
the next argument name was read in its place.

HOSTNAME must be a string or NIL, not 42.

HOSTNAME must be a string or NIL, not :PURPOSE; a keyword here usually means
the value was omitted and the next argument name was read in its place.
```

The docstring keeps your preconditions and loses the clause calling both
parameters positional.

Both regression tests from #23 had to move with the signature, which is the
largest part of the diff. Each was named and written for a swallowed
keyword, and that call is correct now and must not signal, so neither could
keep asserting what it was written to assert.
`chain-verification-rejects-keyword-in-place-of-time` becomes
`non-real-verification-time-is-rejected`, and
`keyword-in-hostname-position-is-rejected` becomes
`non-string-hostname-is-rejected`, each pinning the type rule its guard
actually enforces, with the Finding blocks rewritten to match.

I also added `negative-verification-time-is-rejected`, because nothing
covered the half you added. This is how it asserts:
`tls-certificate-not-yet-valid` is a subtype of `tls-certificate-error`, so
a test that only says the call signals `tls-certificate-error` passes just
as well with the `(>= now 0)` removed. It asserts the condition is not
`tls-certificate-not-yet-valid` instead. I confirmed it goes red with that
half of the guard relaxed.

I updated the three call sites in the library, the fourteen in the
security regression suite, and the CRL example in the README.
`verify-certificate-chain` is not exported, so this is not a change to the
public API. The README reaches it by its double-colon name, though, so
anyone who copied that example needs the new shape, which is why it moved
with the rest.

What I ran: the full suite on Linux under SBCL, 429 checks and no failures,
with the security regression suite at 61. That is your 59 plus the two
assertions in the new test. As before, the Windows and macOS paths are not
exercised here, so the behaviour described above for them is read from the
source rather than observed.
